### PR TITLE
fix: add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "corepack",
   "version": "0.6.0",
+  "license": "MIT",
   "bin": {
     "corepack": "./dist/corepack.js",
     "pnpm": "./dist/pnpm.js",


### PR DESCRIPTION
fixes #28

for reference:

- https://github.com/nodejs/corepack#license-mit
- https://github.com/nodejs/corepack/blob/main/LICENSE.md