### PR TITLE
add license & GitHub info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,15 @@
 {
   "name": "corepack",
   "version": "0.6.0",
+  "homepage": "https://github.com/nodejs/corepack#readme",
+  "bugs": {
+    "url": "https://github.com/nodejs/corepack/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodejs/corepack.git"
+  },
+  "license": "MIT",
   "bin": {
     "corepack": "./dist/corepack.js",
     "pnpm": "./dist/pnpm.js",


### PR DESCRIPTION
supersedes PR #30; fixes #28 see references:

- https://github.com/nodejs/corepack#license-mit
- https://github.com/nodejs/corepack/blob/main/LICENSE.md