### PR TITLE
Adds support for executing arbitrary versions of packages managers

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,7 +15,7 @@
                         "npm": "./bin/npm-cli.js",
                         "npx": "./bin/npx-cli.js"
                     },
-                    "tags": {
+                    "registry": {
                         "type": "npm",
                         "package": "npm"
                     }
@@ -37,7 +37,7 @@
                         "pnpm": "./bin/pnpm.js",
                         "pnpx": "./bin/pnpx.js"
                     },
-                    "tags": {
+                    "registry": {
                         "type": "npm",
                         "package": "pnpm"
                     }
@@ -48,7 +48,7 @@
                         "pnpm": "./bin/pnpm.cjs",
                         "pnpx": "./bin/pnpx.cjs"
                     },
-                    "tags": {
+                    "registry": {
                         "type": "npm",
                         "package": "pnpm"
                     }
@@ -70,7 +70,7 @@
                         "yarn": "./bin/yarn.js",
                         "yarnpkg": "./bin/yarn.js"
                     },
-                    "tags": {
+                    "registry": {
                         "type": "npm",
                         "package": "yarn"
                     }
@@ -79,10 +79,13 @@
                     "name": "yarn",
                     "url": "https://repo.yarnpkg.com/{}/packages/yarnpkg-cli/bin/yarn.js",
                     "bin": ["yarn", "yarnpkg"],
-                    "tags": {
+                    "registry": {
                         "type": "url",
                         "url": "https://repo.yarnpkg.com/tags",
-                        "field": "tags"
+                        "fields": {
+                          "tags": "latest",
+                          "versions": "tags"
+                        }
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corepack",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "homepage": "https://github.com/nodejs/corepack#readme",
   "bugs": {
     "url": "https://github.com/nodejs/corepack/issues"

--- a/sources/types.ts
+++ b/sources/types.ts
@@ -22,20 +22,23 @@ export function isSupportedPackageManager(value: string): value is SupportedPack
   return SupportedPackageManagerSet.has(value as SupportedPackageManagers);
 }
 
-export interface NpmTagSpec {
+export interface NpmRegistrySpec {
   type: `npm`;
   package: string;
 }
 
-export interface UrlTagSpec {
+export interface UrlRegistrySpec {
   type: `url`;
   url: string;
-  field: string;
+  fields: {
+    tags: string;
+    versions: string;
+  };
 }
 
-export type TagSpec =
-    | NpmTagSpec
-    | UrlTagSpec;
+export type RegistrySpec =
+    | NpmRegistrySpec
+    | UrlRegistrySpec;
 
 /**
  * Defines how the package manager is meant to be downloaded and accessed.
@@ -43,7 +46,7 @@ export type TagSpec =
 export interface PackageManagerSpec {
   url: string;
   bin: BinSpec | BinList;
-  tags: TagSpec;
+  registry: RegistrySpec;
 }
 
 /**


### PR DESCRIPTION
The following diff enables the ability to run:

```
corepack yarn@1.22.0 yarn ...
```

In other words, it's now possible to force use a specific version if needed. This is useful for testing purposes, but is also used in Yarn's init workflow (which requires to jump through some hoops).

Additionally, this syntax supports tags (but only this syntax supports it; it's still not possible to set `"packageManager": "canary"` in your package.json):

```
corepack yarn@canary yarn ...
```
