### PR TITLE
Fixes the displayed version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corepack",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "homepage": "https://github.com/nodejs/corepack#readme",
   "bugs": {
     "url": "https://github.com/nodejs/corepack/issues"

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -85,7 +85,8 @@ export async function main(argv: Array<string>, context: CustomContext & Partial
       ...context,
     });
   } else {
-    const cli = new Cli<Context>({binaryName: `corepack`});
+    const binaryVersion = eval(`require`)(`corepack/package.json`).version;
+    const cli = new Cli<Context>({binaryName: `corepack`, binaryVersion});
 
     cli.register(Builtins.HelpCommand);
     cli.register(Builtins.VersionCommand);


### PR DESCRIPTION
The version wasn't properly set, so running `corepack -v` didn't work.