### PR TITLE
Removes vcc from the binaries

### DIFF
--- a/mkshims.ts
+++ b/mkshims.ts
@@ -5,6 +5,10 @@ import path                         from 'path';
 import {Engine}                     from './sources/Engine';
 import {SupportedPackageManagerSet} from './sources/types';
 
+const EXCLUDE_SHIMS = new Set([
+  `vcc.js`,
+]);
+
 const engine = new Engine();
 
 const distDir = path.join(__dirname, `dist`);
@@ -33,8 +37,12 @@ async function main() {
     }
   }
 
-  for (const binaryName of fs.readdirSync(distDir))
+  for (const binaryName of fs.readdirSync(distDir)) {
+    if (EXCLUDE_SHIMS.has(binaryName))
+      continue;
+
     await cmdShim(path.join(distDir, binaryName), path.join(shimsDir, path.basename(binaryName, `.js`)), {createCmdFile: true});
+  }
 
   // The Node distribution doesn't support symlinks, so they copy the shims into
   // the target folder. Since our shims have relative paths, it doesn't work


### PR DESCRIPTION
The `vcc.js` file is just v8-compile-cache compiled to a single JS bundle. Since it's located in the `dist` directory, `mkshims` incorrectly generated shims for it (which isn't useful, as its only purpose is to be required by the other jumpers).

This diff makes sure that this file is excluded from the shim generation.