### PR TITLE
fix: avoid using `eval` to get the corepack version

### DIFF
--- a/sources/main.ts
+++ b/sources/main.ts
@@ -85,8 +85,10 @@ export async function main(argv: Array<string>, context: CustomContext & Partial
       ...context,
     });
   } else {
-    const binaryVersion = eval(`require`)(`corepack/package.json`).version;
-    const cli = new Cli<Context>({binaryName: `corepack`, binaryVersion});
+    const cli = new Cli<Context>({
+      binaryName: `corepack`,
+      binaryVersion: require(`../package.json`).version,
+    });
 
     cli.register(Builtins.HelpCommand);
     cli.register(Builtins.VersionCommand);


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/nodejs/corepack/pull/42 used `eval` to get the current corepack version which doesn't work if the path to corepack isn't `.../node_modules/corepack`

**How did you fix it?**

Use a statically analysable `require`

