### PR TITLE
Fixes invalid option name in Enable/Disable's help

### DIFF
--- a/sources/commands/Disable.ts
+++ b/sources/commands/Disable.ts
@@ -16,7 +16,7 @@ export class DisableCommand extends Command<Context> {
     details: `
       When run, this command will remove the shims for the specified package managers from the install directory, or all shims if no parameters are passed.
 
-      By default it will locate the install directory by running the equivalent of \`which corepack\`, but this can be tweaked by explicitly passing the install directory via the \`--bin-folder\` flag.
+      By default it will locate the install directory by running the equivalent of \`which corepack\`, but this can be tweaked by explicitly passing the install directory via the \`--install-directory\` flag.
     `,
     examples: [[
       `Disable all shims, removing them if they're next to the \`coreshim\` binary`,

--- a/sources/commands/Enable.ts
+++ b/sources/commands/Enable.ts
@@ -17,7 +17,7 @@ export class EnableCommand extends Command<Context> {
     details: `
       When run, this commmand will check whether the shims for the specified package managers can be found with the correct values inside the install directory. If not, or if they don't exist, they will be created.
 
-      By default it will locate the install directory by running the equivalent of \`which corepack\`, but this can be tweaked by explicitly passing the install directory via the \`--bin-folder\` flag.
+      By default it will locate the install directory by running the equivalent of \`which corepack\`, but this can be tweaked by explicitly passing the install directory via the \`--install-directory\` flag.
     `,
     examples: [[
       `Enable all shims, putting them next to the \`corepath\` binary`,


### PR DESCRIPTION
The help message references the wrong option name.

Fixes #80 