### PR TITLE
tools: add `coverage` folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /package.tgz
 
 /shims
+/coverage


### PR DESCRIPTION
When running `jest --collect-coverage` a `coverage` folder is created,
which should not be committed.