### PR TITLE
perf: load binaries in the same process

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "build": "rm -rf dist shims && webpack && ts-node ./mkshims.ts",
-    "corepack": "ts-node ./sources/main.ts",
+    "corepack": "ts-node ./sources/_entryPoint.ts",
     "prepack": "node ./.yarn/releases/*.*js build",
     "postpack": "rm -rf dist shims",
     "typecheck": "tsc --noEmit",

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -5,11 +5,11 @@ import semver                                                 from 'semver';
 
 import defaultConfig                                          from '../config.json';
 
-import * as folderUtils                                       from './folderUtils';
 import * as corepackUtils                                     from './corepackUtils';
+import * as folderUtils                                       from './folderUtils';
 import * as semverUtils                                       from './semverUtils';
-import {SupportedPackageManagers, SupportedPackageManagerSet} from './types';
 import {Config, Descriptor, Locator}                          from './types';
+import {SupportedPackageManagers, SupportedPackageManagerSet} from './types';
 
 
 export class Engine {

--- a/sources/_entryPoint.ts
+++ b/sources/_entryPoint.ts
@@ -1,0 +1,8 @@
+import {runMain} from './main';
+
+// Used by the generated shims
+export {runMain};
+
+// Using `eval` to be sure that Webpack doesn't transform it
+if (process.mainModule === eval(`module`))
+  runMain(process.argv.slice(2));

--- a/sources/commands/Enable.ts
+++ b/sources/commands/Enable.ts
@@ -5,6 +5,7 @@ import path                                                              from 'p
 import which                                                             from 'which';
 
 import {Context}                                                         from '../main';
+import * as nodeUtils                                                    from '../nodeUtils';
 import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types';
 
 export class EnableCommand extends Command<Context> {
@@ -51,7 +52,7 @@ export class EnableCommand extends Command<Context> {
     installDirectory = fs.realpathSync(installDirectory);
 
     // We use `eval` so that Webpack doesn't statically transform it.
-    const manifestPath = eval(`require`).resolve(`corepack/package.json`);
+    const manifestPath = nodeUtils.dynamicRequire.resolve(`corepack/package.json`);
 
     const distFolder = path.join(path.dirname(manifestPath), `dist`);
     if (!fs.existsSync(distFolder))

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -5,8 +5,8 @@ import {DisableCommand}                                          from './command
 import {EnableCommand}                                           from './commands/Enable';
 import {HydrateCommand}                                          from './commands/Hydrate';
 import {PrepareCommand}                                          from './commands/Prepare';
-import * as miscUtils                                            from './miscUtils';
 import * as corepackUtils                                        from './corepackUtils';
+import * as miscUtils                                            from './miscUtils';
 import * as specUtils                                            from './specUtils';
 import {Locator, SupportedPackageManagers, Descriptor}           from './types';
 
@@ -19,7 +19,7 @@ type PackageManagerRequest = {
   binaryVersion: string | null;
 };
 
-function getPackageManagerRequestFromCli(parameter: string | undefined, context: CustomContext & Partial<Context>): PackageManagerRequest {
+function getPackageManagerRequestFromCli(parameter: string | undefined, context: CustomContext & Partial<Context>): PackageManagerRequest | null {
   if (!parameter)
     return null;
 
@@ -82,13 +82,19 @@ async function executePackageManagerRequest({packageManager, binaryName, binaryV
     throw new UsageError(`Failed to successfully resolve '${descriptor.range}' to a valid ${descriptor.name} release`);
 
   const installSpec = await context.engine.ensurePackageManager(resolved);
-  const exitCode = await corepackUtils.runVersion(installSpec, resolved, binaryName, args, context);
 
-  return exitCode;
+  return await corepackUtils.runVersion(installSpec, binaryName, args);
 }
 
-export async function main(argv: Array<string>, context: CustomContext & Partial<Context>) {
+async function main(argv: Array<string>) {
   const corepackVersion = require(`../package.json`).version;
+
+  // Because we load the binaries in the same process, we don't support custom contexts.
+  const context = {
+    ...Cli.defaultContext,
+    cwd: process.cwd(),
+    engine: new Engine(),
+  };
 
   const [firstArg, ...restArgs] = argv;
   const request = getPackageManagerRequestFromCli(firstArg, context);
@@ -110,10 +116,7 @@ export async function main(argv: Array<string>, context: CustomContext & Partial
     cli.register(HydrateCommand);
     cli.register(PrepareCommand);
 
-    return await cli.run(argv, {
-      ...Cli.defaultContext,
-      ...context,
-    });
+    return await cli.run(argv, context);
   } else {
     // Otherwise, we create a single-command CLI to run the specified package manager (we still use Clipanion in order to pretty-print usage errors).
     const cli = new Cli({
@@ -129,25 +132,16 @@ export async function main(argv: Array<string>, context: CustomContext & Partial
       }
     });
 
-    return await cli.run(restArgs, {
-      ...Cli.defaultContext,
-      ...context,
-    });
+    return await cli.run(restArgs, context);
   }
 }
 
+// Important: this is the only function that the corepack binary exports.
 export function runMain(argv: Array<string>) {
-  main(argv, {
-    cwd: process.cwd(),
-    engine: new Engine(),
-  }).then(exitCode => {
+  main(argv).then(exitCode => {
     process.exitCode = exitCode;
   }, err => {
     console.error(err.stack);
     process.exitCode = 1;
   });
 }
-
-// Using `eval` to be sure that Webpack doesn't transform it
-if (process.mainModule === eval(`module`))
-  runMain(process.argv.slice(2));

--- a/sources/module.d.ts
+++ b/sources/module.d.ts
@@ -1,0 +1,16 @@
+import 'module';
+
+declare module 'module' {
+  const _cache: {[p: string]: NodeModule};
+
+  function _nodeModulePaths(from: string): Array<string>;
+  function _resolveFilename(request: string, parent: NodeModule | null | undefined, isMain: boolean): string;
+}
+
+declare global {
+  namespace NodeJS {
+    interface Module {
+      load(path: string): void;
+    }
+  }
+}

--- a/sources/nodeUtils.ts
+++ b/sources/nodeUtils.ts
@@ -1,0 +1,43 @@
+import Module from 'module';
+import path   from 'path';
+
+declare const __non_webpack_require__: NodeRequire | undefined;
+
+export const dynamicRequire: NodeRequire = typeof __non_webpack_require__ !== `undefined`
+  ? __non_webpack_require__
+  : require;
+
+function getV8CompileCachePath() {
+  return typeof __non_webpack_require__ !== `undefined`
+    ? `./vcc.js`
+    : `corepack/dist/vcc.js`;
+}
+
+export function registerV8CompileCache() {
+  const vccPath = getV8CompileCachePath();
+  dynamicRequire(vccPath);
+}
+
+/**
+ * Loads a module as a main module, enabling the `require.main === module` pattern.
+ */
+export function loadMainModule(id: string): void {
+  const modulePath = Module._resolveFilename(id, null, true);
+
+  const module = new Module(modulePath, undefined);
+
+  module.filename = modulePath;
+  module.paths = Module._nodeModulePaths(path.dirname(modulePath));
+
+  Module._cache[modulePath] = module;
+
+  process.mainModule = module;
+  module.id = `.`;
+
+  try {
+    return module.load(modulePath);
+  } catch (error) {
+    delete Module._cache[modulePath];
+    throw error;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,10 @@
     "module": "commonjs",
     "resolveJsonModule": true,
     "skipLibCheck": true,
+    "strict": true,
     "target": "es2017"
+  },
+  "ts-node": {
+    "transpileOnly": true
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   devtool: false,
   target: `node`,
   entry: {
-    [`corepack`]: `./sources/main.ts`,
+    [`corepack`]: `./sources/_entryPoint.ts`,
     [`vcc`]: `v8-compile-cache`,
   },
   output: {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

While looking into improving Yarn's startup time, we've observed the fact that corepack adds extra overhead by spawning a new process to run the invoked binary.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

This PR makes `corepack` load binaries in the same process, removing the `spawn` indirection and considerably improving the startup time:

<table>
<tr>
	<td>package-manager --version
	<td>Before
	<td>After
<tr>
	<td>yarn@3.2.0
	<td>183.1 ms
	<td>159.7 ms
<tr>
	<td>pnpm@6.29.1
	<td>92.0 ms
	<td>69.8 ms
<tr>
	<td>npm@8.1.0
	<td>160.8 ms
	<td>131.6 ms
</table>

The way it achieves this is by modifying `process.{argv,execArgv}` and `process.mainModule` (and the module cache to make sure that `require.main === module` keeps working) to trick the binary into thinking that it was spawned directly instead of having been loaded into the current process.

It might feel a bit magical at first, but we feel it's worth it.