### PR TITLE
Fixes `corepack prepare` when no additional arguments are passed

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -18,6 +18,7 @@ const moduleWrapper = tsserver => {
   const pnpApi = require(`pnpapi`);
 
   const isVirtual = str => str.match(/\/(\$\$virtual|__virtual__)\//);
+  const isPortal = str => str.startsWith("portal:/");
   const normalize = str => str.replace(/\\/g, `/`).replace(/^\/?/, `/`);
 
   const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
@@ -44,7 +45,7 @@ const moduleWrapper = tsserver => {
       const resolved = isVirtual(str) ? pnpApi.resolveVirtual(str) : str;
       if (resolved) {
         const locator = pnpApi.findPackageLocator(resolved);
-        if (locator && dependencyTreeRoots.has(`${locator.name}@${locator.reference}`)) {
+        if (locator && (dependencyTreeRoots.has(`${locator.name}@${locator.reference}`) || isPortal(locator.reference))) {
           str = resolved;
         }
       }
@@ -60,16 +61,24 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
-          // Update Oct 8 2021: VSCode changed their format in 1.61.
+          // Update 2021-10-08: VSCode changed their format in 1.61.
           // Before | ^zip:/c:/foo/bar.zip/package.json
           // After  | ^/zip//c:/foo/bar.zip/package.json
+          //
+          // Update 2022-04-06: VSCode changed the format in 1.66.
+          // Before | ^/zip//c:/foo/bar.zip/package.json
+          // After  | ^/zip/c:/foo/bar.zip/package.json
           //
           case `vscode <1.61`: {
             str = `^zip:${str}`;
           } break;
 
-          case `vscode`: {
+          case `vscode <1.66`: {
             str = `^/zip/${str}`;
+          } break;
+
+          case `vscode`: {
+            str = `^/zip${str}`;
           } break;
 
           // To make "go to definition" work,
@@ -85,7 +94,7 @@ const moduleWrapper = tsserver => {
           // everything else is up to neovim
           case `neovim`: {
             str = normalize(resolved).replace(/\.zip\//, `.zip::`);
-            str = `zipfile:${str}`;
+            str = `zipfile://${str}`;
           } break;
 
           default: {
@@ -100,8 +109,7 @@ const moduleWrapper = tsserver => {
 
   function fromEditorPath(str) {
     switch (hostInfo) {
-      case `coc-nvim`:
-      case `neovim`: {
+      case `coc-nvim`: {
         str = str.replace(/\.zip::/, `.zip/`);
         // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
         // So in order to convert it back, we use .* to match all the thing
@@ -109,6 +117,12 @@ const moduleWrapper = tsserver => {
         return process.platform === `win32`
           ? str.replace(/^.*zipfile:\//, ``)
           : str.replace(/^.*zipfile:/, ``);
+      } break;
+
+      case `neovim`: {
+        str = str.replace(/\.zip::/, `.zip/`);
+        // The path for neovim is in format of zipfile:///<pwd>/.yarn/...
+        return str.replace(/^zipfile:\/\//, ``);
       } break;
 
       case `vscode`:
@@ -154,8 +168,12 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
-        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\/1\.([1-5][0-9]|60)\./)) {
-          hostInfo += ` <1.61`;
+        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
+          if (/(\/|-)1\.([1-5][0-9]|60)\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.61`;
+          } else if (/(\/|-)1\.(6[1-5])\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.66`;
+          }
         }
       }
 

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -18,6 +18,7 @@ const moduleWrapper = tsserver => {
   const pnpApi = require(`pnpapi`);
 
   const isVirtual = str => str.match(/\/(\$\$virtual|__virtual__)\//);
+  const isPortal = str => str.startsWith("portal:/");
   const normalize = str => str.replace(/\\/g, `/`).replace(/^\/?/, `/`);
 
   const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
@@ -44,7 +45,7 @@ const moduleWrapper = tsserver => {
       const resolved = isVirtual(str) ? pnpApi.resolveVirtual(str) : str;
       if (resolved) {
         const locator = pnpApi.findPackageLocator(resolved);
-        if (locator && dependencyTreeRoots.has(`${locator.name}@${locator.reference}`)) {
+        if (locator && (dependencyTreeRoots.has(`${locator.name}@${locator.reference}`) || isPortal(locator.reference))) {
           str = resolved;
         }
       }
@@ -60,16 +61,24 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
-          // Update Oct 8 2021: VSCode changed their format in 1.61.
+          // Update 2021-10-08: VSCode changed their format in 1.61.
           // Before | ^zip:/c:/foo/bar.zip/package.json
           // After  | ^/zip//c:/foo/bar.zip/package.json
+          //
+          // Update 2022-04-06: VSCode changed the format in 1.66.
+          // Before | ^/zip//c:/foo/bar.zip/package.json
+          // After  | ^/zip/c:/foo/bar.zip/package.json
           //
           case `vscode <1.61`: {
             str = `^zip:${str}`;
           } break;
 
-          case `vscode`: {
+          case `vscode <1.66`: {
             str = `^/zip/${str}`;
+          } break;
+
+          case `vscode`: {
+            str = `^/zip${str}`;
           } break;
 
           // To make "go to definition" work,
@@ -85,7 +94,7 @@ const moduleWrapper = tsserver => {
           // everything else is up to neovim
           case `neovim`: {
             str = normalize(resolved).replace(/\.zip\//, `.zip::`);
-            str = `zipfile:${str}`;
+            str = `zipfile://${str}`;
           } break;
 
           default: {
@@ -100,8 +109,7 @@ const moduleWrapper = tsserver => {
 
   function fromEditorPath(str) {
     switch (hostInfo) {
-      case `coc-nvim`:
-      case `neovim`: {
+      case `coc-nvim`: {
         str = str.replace(/\.zip::/, `.zip/`);
         // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
         // So in order to convert it back, we use .* to match all the thing
@@ -109,6 +117,12 @@ const moduleWrapper = tsserver => {
         return process.platform === `win32`
           ? str.replace(/^.*zipfile:\//, ``)
           : str.replace(/^.*zipfile:/, ``);
+      } break;
+
+      case `neovim`: {
+        str = str.replace(/\.zip::/, `.zip/`);
+        // The path for neovim is in format of zipfile:///<pwd>/.yarn/...
+        return str.replace(/^zipfile:\/\//, ``);
       } break;
 
       case `vscode`:
@@ -154,8 +168,12 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
-        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\/1\.([1-5][0-9]|60)\./)) {
-          hostInfo += ` <1.61`;
+        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
+          if (/(\/|-)1\.([1-5][0-9]|60)\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.61`;
+          } else if (/(\/|-)1\.(6[1-5])\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.66`;
+          }
         }
       }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -179,10 +179,17 @@ it(`should allow to call "prepare" without arguments within a configured project
       exitCode: 0,
     });
 
-    await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
-      stdout: `1.0.0\n`,
-      exitCode: 0,
-    });
+    // Disable the network to make sure we don't succeed by accident
+    process.env.COREPACK_ENABLE_NETWORK = `0`;
+
+    try {
+      await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
+        stdout: `1.0.0\n`,
+        exitCode: 0,
+      });
+    } finally {
+      delete process.env.COREPACK_ENABLE_NETWORK;
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #96

The existing implementation of `prepare` iterates over an array of `string | Descriptor` requests and only looks up the project version when `typeof request === 'undefined'`, which is never true. This wasn't caught by the test suite since the network was left enabled.

I've updated the command to instead look up the project spec when the specs list is empty, before the loop starts.