### PR TITLE
ci: simplify `Testing chores` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - run: |
-          git fetch --no-tags --unshallow origin HEAD main
+        with:
+          fetch-depth: 2
 
       - uses: actions/setup-node@v3
         with:
@@ -23,14 +22,10 @@ jobs:
 
       - name: "Check that the cache files are consistent with their remote sources"
         run: |
-          if [[ $(git diff --name-only "$(git merge-base origin/"$TARGET_BRANCH" HEAD)" HEAD -- .yarn/cache | wc -l) -gt 0 ]]; then
+          git diff --exit-code --quiet HEAD^ -- .yarn/cache || \
             corepack yarn --immutable --immutable-cache --check-cache
-          fi
-        shell: bash
         if: |
           github.event.pull_request != ''
-        env:
-          TARGET_BRANCH: ${{github.event.pull_request.base.ref}}
 
       - name: "Check for type errors"
         run: corepack yarn typecheck
@@ -60,5 +55,5 @@ jobs:
 
       - run: corepack yarn install --immutable
       - run: corepack yarn build # We need the stubs to run the tests
-      - run: corepack yarn eslint
-      - run: corepack yarn jest
+      - run: corepack yarn lint
+      - run: corepack yarn test

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "scripts": {
     "build": "rm -rf dist shims && webpack && ts-node ./mkshims.ts",
     "corepack": "ts-node ./sources/_entryPoint.ts",
+    "lint": "yarn eslint",
     "prepack": "yarn build",
     "postpack": "rm -rf dist shims",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
On a merge commit, `HEAD^` refers to the base branch commit, so we can use it instead of `git merge-base origin/"$TARGET_BRANCH" HEAD`. The upside is we don't have to fetch the whole repo anymore, which should speed up the CI.