### PR TITLE
ci: test on all supported Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
-          
+          node-version: lts/*
+
       - name: Get the Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
@@ -46,6 +44,8 @@ jobs:
       matrix:
         node:
           - 14
+          - 16
+          - 18
         platform:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
- Use the latest LTS Node.js version available rather than having an arbitrary `14` for `Testing chores` job.
- Add Node.js 16.x and 18.x to the test matrix.