### PR TITLE
chore: fix `Version Sync` action

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -42,7 +42,7 @@ jobs:
             },
           }" > config.json
 
-      - uses: gr2m/create-or-update-pull-request-action@466b1b84c3291c6c69bc56377a6de54a1f4a297c
+      - uses: gr2m/create-or-update-pull-request-action@6720400cad8e74d7adc64640e4e6ea6748b83d8f
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.
         env:


### PR DESCRIPTION
> I think we should use https://github.com/gr2m/create-or-update-pull-request-action/commit/6720400cad8e74d7adc64640e4e6ea6748b83d8f instead.
https://github.com/gr2m/create-or-update-pull-request-action/blob/6720400cad8e74d7adc64640e4e6ea6748b83d8f/dist/index.js
> There's no `/dist/` in their master branch.

_Originally posted by @LiviaMedeiros in https://github.com/nodejs/node/issues/43377#issuecomment-1152883511_