### PR TITLE
chore: fix GHA automations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           release-type: node
           package-name: corepack
+          bump-minor-pre-major: true # TODO: remove this when releasing v1.0.0.
 
   npm-publish:
     needs: release-please

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -50,5 +50,5 @@ jobs:
         with:
           body: This is an automated update of package manager versions
           branch: actions/tools-update-config.json
-          commit-message: "chore: update package manager versions"
-          title: "chore: update package manager versions"
+          commit-message: "feat: update package manager versions"
+          title: "feat: update package manager versions"


### PR DESCRIPTION
According to https://github.com/google-github-actions/release-please-action#configuration, `bump-minor-pre-major` option can be used to stay on `0.x` even if we introduce breaking changes.

According to https://github.com/googleapis/release-please#release-please-bot-does-not-create-a-release-pr-why, we want to use `feat` or `fix` for the automation that updates the package manager versions, otherwise release-please won't create a PR.