### PR TITLE
Fixes publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: |
             ${{runner.os}}-yarn-
 
-      - run:
+      - run: |
           corepack yarn install --immutable
           corepack yarn npm publish
         env:


### PR DESCRIPTION
The publish script uses `run:` instead of `run: |`, which causes Yaml to discard line returns