### PR TITLE
Only set bins on pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,6 @@
     "url": "https://github.com/nodejs/corepack.git"
   },
   "license": "MIT",
-  "bin": {
-    "corepack": "./dist/corepack.js",
-    "pnpm": "./dist/pnpm.js",
-    "pnpx": "./dist/pnpx.js",
-    "yarn": "./dist/yarn.js",
-    "yarnpkg": "./dist/yarnpkg.js"
-  },
   "packageManager": "yarn@4.0.0-rc.6",
   "devDependencies": {
     "@babel/core": "^7.14.3",
@@ -68,6 +61,13 @@
     "LICENSE.md"
   ],
   "publishConfig": {
+    "bin": {
+      "corepack": "./dist/corepack.js",
+      "pnpm": "./dist/pnpm.js",
+      "pnpx": "./dist/pnpx.js",
+      "yarn": "./dist/yarn.js",
+      "yarnpkg": "./dist/yarnpkg.js"
+    },
     "executableFiles": [
       "./dist/npm.js",
       "./dist/npx.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2255,12 +2255,6 @@ __metadata:
     webpack: "npm:^5.38.1"
     webpack-cli: "npm:^4.0.0"
     which: "npm:^2.0.2"
-  bin:
-    corepack: ./dist/corepack.js
-    pnpm: ./dist/pnpm.js
-    pnpx: ./dist/pnpx.js
-    yarn: ./dist/yarn.js
-    yarnpkg: ./dist/yarnpkg.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The package.json contains a `bin` entry point to `dist/yarn.js`. As a result, when a script runs, this bin entry is injected into the PATH. While it usually works fine, in this case the bin is called `yarn`, so it overrides the `yarn` binary usually present in the PATH and that `prepack` calls to run `yarn build`. Given that `dist/yarn.js` doesn't exist yet at this point in time, the packing fails.

This diff fixes that by only setting the `bin` entries inside the published package, so that they don't override the local values during development.