### PR TITLE
feat: download the latest version instead of a pinned one

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,16 @@ Just use your package managers as you usually would. Run `yarn install` in Yarn 
 
 ## Known Good Releases
 
-When running Yarn or pnpm within projects that don't list a supported package manager, Corepack will default to a set of Known Good Releases. In a way, you can compare this to Node.js, where each version ships with a specific version of npm.
+When running Corepack within projects that don't list a supported package
+manager, it will default to a set of Known Good Releases. In a way, you can
+compare this to Node.js, where each version ships with a specific version of npm.
 
-The Known Good Releases can be updated system-wide using the `--activate` flag from the `corepack prepare` and `corepack hydrate` commands.
+If there is no Known Good Release for the requested package manager, Corepack
+looks up the npm registry for the latest available version and cache it for
+future use.
+
+The Known Good Releases can be updated system-wide using the `--activate` flag
+from the `corepack prepare` and `corepack hydrate` commands.
 
 ## Offline Workflow
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ This command will retrieve the given package manager from the specified archive 
 
 - `COREPACK_ENABLE_NETWORK` can be set to `0` to prevent Corepack from accessing the network (in which case you'll be responsible for hydrating the package manager versions that will be required for the projects you'll run, using `corepack hydrate`).
 
+- `COREPACK_NO_LOOKUP` can be set in order to instruct Corepack not to lookup on the remote registry for the latest version of the selected package manager.
+
 - `COREPACK_HOME` can be set in order to define where Corepack should install the package managers. By default it is set to `$HOME/.node/corepack`.
 
 - `COREPACK_ROOT` has no functional impact on Corepack itself; it's automatically being set in your environment by Corepack when it shells out to the underlying package managers, so that they can feature-detect its presence (useful for commands like `yarn init`).

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ This command will retrieve the given package manager from the specified archive 
 
 - `COREPACK_ENABLE_NETWORK` can be set to `0` to prevent Corepack from accessing the network (in which case you'll be responsible for hydrating the package manager versions that will be required for the projects you'll run, using `corepack hydrate`).
 
-- `COREPACK_NO_LOOKUP` can be set in order to instruct Corepack not to lookup on the remote registry for the latest version of the selected package manager.
+- `COREPACK_DEFAULT_TO_LATEST` can be set to `0` in order to instruct Corepack
+  not to lookup on the remote registry for the latest version of the selected
+  package manager.
 
 - `COREPACK_HOME` can be set in order to define where Corepack should install the package managers. By default it is set to `$HOME/.node/corepack`.
 

--- a/config.json
+++ b/config.json
@@ -2,6 +2,10 @@
   "definitions": {
     "npm": {
       "default": "8.13.1",
+      "fetchLatestFrom": {
+        "type": "npm",
+        "package": "npm"
+      },
       "transparent": {
         "commands": [
           [
@@ -29,6 +33,10 @@
     },
     "pnpm": {
       "default": "7.3.0",
+      "fetchLatestFrom": {
+        "type": "npm",
+        "package": "pnpm"
+      },
       "transparent": {
         "commands": [
           [
@@ -71,6 +79,10 @@
     },
     "yarn": {
       "default": "1.22.19",
+      "fetchLatestFrom": {
+        "type": "npm",
+        "package": "yarn"
+      },
       "transparent": {
         "default": "3.2.1",
         "commands": [

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -1,6 +1,7 @@
 import {UsageError}                                           from 'clipanion';
 import fs                                                     from 'fs';
 import path                                                   from 'path';
+import process                                                from 'process';
 import semver                                                 from 'semver';
 
 import defaultConfig                                          from '../config.json';
@@ -77,7 +78,7 @@ export class Engine {
       }
     }
 
-    if (process.env.COREPACK_NO_LOOKUP)
+    if (process.env.COREPACK_DEFAULT_TO_LATEST === `0`)
       return definition.default;
 
     const reference = await corepackUtils.fetchLatestStableVersion(definition.fetchLatestFrom);

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -81,8 +81,15 @@ export class Engine {
     if (process.env.COREPACK_NO_LOOKUP)
       return definition.default;
 
-    const latest = await fetchAsJson(`https://registry.npmjs.org/${packageManager}`);
-    return latest[`dist-tags`].latest;
+    const {[`dist-tags`]: {latest}, versions: {[latest]: {dist: {shasum}}}} = await fetchAsJson(`https://registry.npmjs.org/${packageManager}`);
+    const reference = `${latest}+sha1.${shasum}`;
+
+    await this.activatePackageManager({
+      name: packageManager,
+      reference,
+    });
+
+    return reference;
   }
 
   async activatePackageManager(locator: Locator) {

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -78,6 +78,9 @@ export class Engine {
       }
     }
 
+    if (process.env.COREPACK_NO_LOOKUP)
+      return definition.default;
+
     const latest = await fetchAsJson(`https://registry.npmjs.org/${packageManager}`);
     return latest[`dist-tags`].latest;
   }

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -7,7 +7,6 @@ import defaultConfig                                          from '../config.js
 
 import * as corepackUtils                                     from './corepackUtils';
 import * as folderUtils                                       from './folderUtils';
-import {fetchAsJson}                                          from './httpUtils';
 import * as semverUtils                                       from './semverUtils';
 import {Config, Descriptor, Locator}                          from './types';
 import {SupportedPackageManagers, SupportedPackageManagerSet} from './types';
@@ -81,8 +80,7 @@ export class Engine {
     if (process.env.COREPACK_NO_LOOKUP)
       return definition.default;
 
-    const {[`dist-tags`]: {latest}, versions: {[latest]: {dist: {shasum}}}} = await fetchAsJson(`https://registry.npmjs.org/${packageManager}`);
-    const reference = `${latest}+sha1.${shasum}`;
+    const reference = await corepackUtils.fetchLatestStableVersion(definition.fetchLatestFrom);
 
     await this.activatePackageManager({
       name: packageManager,

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -9,6 +9,23 @@ import * as httpUtils                                          from './httpUtils
 import * as nodeUtils                                          from './nodeUtils';
 import {RegistrySpec, Descriptor, Locator, PackageManagerSpec} from './types';
 
+export async function fetchLatestStableVersion(spec: RegistrySpec) {
+  switch (spec.type) {
+    case `npm`: {
+      const {[`dist-tags`]: {latest}, versions: {[latest]: {dist: {shasum}}}} =
+        await httpUtils.fetchAsJson(`https://registry.npmjs.org/${spec.package}`);
+      return `${latest}+sha1.${shasum}`;
+    }
+    case `url`: {
+      const data = await httpUtils.fetchAsJson(spec.url);
+      return data[spec.fields.tags].stable;
+    }
+    default: {
+      throw new Error(`Unsupported specification ${JSON.stringify(spec)}`);
+    }
+  }
+}
+
 export async function fetchAvailableTags(spec: RegistrySpec): Promise<Record<string, string>> {
   switch (spec.type) {
     case `npm`: {

--- a/sources/types.ts
+++ b/sources/types.ts
@@ -63,6 +63,11 @@ export interface Config {
       default: string;
 
       /**
+       * Defines how to fetch the latest version from a remote registry.
+       */
+      fetchLatestFrom: RegistrySpec;
+
+      /**
        * Defines a set of commands that are fine to run even if the user isn't
        * in a project configured for the specified package manager. For instance,
        * we would use that to be able to run "pnpx" even inside Yarn projects.

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6,6 +6,7 @@ import {runCli}                                    from './_runCli';
 
 beforeEach(async () => {
   process.env.COREPACK_HOME = npath.fromPortablePath(await xfs.mktempPromise());
+  process.env.COREPACK_NO_LOOKUP = `1`;
 });
 
 const testedPackageManagers: Array<[string, string]> = [

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6,7 +6,7 @@ import {runCli}                                    from './_runCli';
 
 beforeEach(async () => {
   process.env.COREPACK_HOME = npath.fromPortablePath(await xfs.mktempPromise());
-  process.env.COREPACK_NO_LOOKUP = `1`;
+  process.env.COREPACK_DEFAULT_TO_LATEST = `0`;
 });
 
 it(`should refuse to download a package manager if the hash doesn't match`, async () => {


### PR DESCRIPTION
This PR ensures that fresh install of Corepack would always use the latest available version for a given package manager.

We probably want to add a command to clear the cache for `lastKnownGood` version (although I think that's more or less what `corepack prepare` is doing), and/or have a expiracy date for the `lastKnownGood` version to make Corepack update the default version from time to time.

Fixes: https://github.com/nodejs/corepack/issues/93