### PR TITLE
feat: add support for tags and ranges in `prepare` command

### DIFF
--- a/sources/commands/Prepare.ts
+++ b/sources/commands/Prepare.ts
@@ -25,6 +25,9 @@ export class PrepareCommand extends Command<Context> {
       `Prepare a specific Yarn version`,
       `$0 prepare yarn@2.2.2`,
     ], [
+      `Prepare the latest available pnpm version`,
+      `$0 prepare pnpm@latest --activate`,
+    ], [
       `Generate an archive for a specific Yarn version`,
       `$0 prepare yarn@2.2.2 -o`,
     ], [
@@ -50,7 +53,7 @@ export class PrepareCommand extends Command<Context> {
     tolerateBoolean: true,
   });
 
-  specs = Option.Rest()
+  specs = Option.Rest();
 
   async execute() {
     if (this.all && this.specs.length > 0)
@@ -79,10 +82,10 @@ export class PrepareCommand extends Command<Context> {
 
     for (const request of specs) {
       const spec = typeof request === `string`
-        ? specUtils.parseSpec(request, `CLI arguments`)
+        ? specUtils.parseSpec(request, `CLI arguments`, {enforceExactVersion: false})
         : request;
 
-      const resolved = await this.context.engine.resolveDescriptor(spec);
+      const resolved = await this.context.engine.resolveDescriptor(spec, {allowTags: true});
       if (resolved === null)
         throw new UsageError(`Failed to successfully resolve '${spec.range}' to a valid ${spec.name} release`);
 

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -7,13 +7,13 @@ import {Descriptor, Locator, isSupportedPackageManager} from './types';
 
 const nodeModulesRegExp = /[\\/]node_modules[\\/](@[^\\/]*[\\/])?([^@\\/][^\\/]*)$/;
 
-export function parseSpec(raw: unknown, source?: string): Descriptor {
+export function parseSpec(raw: unknown, source: string, {enforceExactVersion = true} = {}): Descriptor {
   if (typeof raw !== `string`)
     throw new UsageError(`Invalid package manager specification in ${source}; expected a string`);
 
   const match = raw.match(/^(?!_)(.+)@(.+)$/);
-  if (match === null || !semver.valid(match[2]))
-    throw new UsageError(`Invalid package manager specification in ${source}; expected a semver version`);
+  if (match === null || (enforceExactVersion && !semver.valid(match[2])))
+    throw new UsageError(`Invalid package manager specification in ${source}; expected a semver version${enforceExactVersion ? `` : `, range, or tag`}`);
 
   if (!isSupportedPackageManager(match[1]))
     throw new UsageError(`Unsupported package manager specification (${match})`);


### PR DESCRIPTION
This would allow to keep up-to-date the "default" version of each package managers.

Fixes: https://github.com/nodejs/corepack/issues/72