### PR TITLE
chore(ci): run `Version Sync` on Friday

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -3,8 +3,8 @@ name: Version Sync
 on:
   workflow_dispatch:
   schedule:
-    # Run once a week at 00:05 UTC on Sunday.
-    - cron: 5 0 * * 0
+    # Run once a week at 00:05 UTC on Friday.
+    - cron: 5 0 * * 5
 
 jobs:
   build:


### PR DESCRIPTION
Node.js' Version Sync workflow runs on Sunday, it makes sense to run
our own before that so we have to time to publish a release on time.