### PR TITLE
fix: add `npm bin` to transparent commands

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,10 @@
         "commands": [
           [
             "npm",
+            "bin"
+          ],
+          [
+            "npm",
             "init"
           ],
           [


### PR DESCRIPTION
- Related to https://github.com/nodejs/corepack/issues/157