### PR TITLE
test: wait for stdio streams of process to close

### DIFF
--- a/tests/_runCli.ts
+++ b/tests/_runCli.ts
@@ -24,7 +24,7 @@ export async function runCli(cwd: PortablePath, argv: Array<string>) {
       reject(error);
     });
 
-    child.on(`exit`, exitCode => {
+    child.on(`close`, exitCode => {
       resolve({
         exitCode,
         stdout: Buffer.concat(out).toString(),


### PR DESCRIPTION
**What's the problem this PR addresses?**

`runCli` uses the `exit` event to know when a process finishes executing but the `exit` event can be called before the `stdio` streams are flushed which causes a race condition where it sometimes wont get the `stdout` / `stderr` value.

Fixes https://github.com/nodejs/corepack/runs/7926771653?check_suite_focus=true#step:8:32

**How did you fix it?**

Switch from the `exit` event to the `close` event which is called after the `stdio` streams are closed.