### PR TITLE
refactor: simplify `v8-compile-cache` setup

### DIFF
--- a/mkshims.ts
+++ b/mkshims.ts
@@ -6,9 +6,6 @@ import {Engine}                     from './sources/Engine';
 import {SupportedPackageManagerSet} from './sources/types';
 
 function shouldGenerateShim(name: string) {
-  if (name.startsWith(`vendors`))
-    return false;
-
   return !name.startsWith(`vendors`);
 }
 

--- a/mkshims.ts
+++ b/mkshims.ts
@@ -6,11 +6,9 @@ import {Engine}                     from './sources/Engine';
 import {SupportedPackageManagerSet} from './sources/types';
 
 function shouldGenerateShim(name: string) {
-  if (name === 'vcc.js') {
+  if (name.startsWith(`vendors`))
     return false;
-  } else if (name.startsWith('vendors')) {
-    return false;
-  }
+
   return true;
 }
 

--- a/mkshims.ts
+++ b/mkshims.ts
@@ -9,7 +9,7 @@ function shouldGenerateShim(name: string) {
   if (name.startsWith(`vendors`))
     return false;
 
-  return true;
+  return !name.startsWith(`vendors`);
 }
 
 const engine = new Engine();

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -184,7 +184,8 @@ export async function runVersion(installSpec: { location: string, spec: PackageM
   if (!binPath)
     throw new Error(`Assertion failed: Unable to locate path for bin '${binName}'`);
 
-  nodeUtils.registerV8CompileCache();
+  // @ts-expect-error - No types
+  await import(`v8-compile-cache`);
 
   // We load the binary into the current process,
   // while making it think it was spawned.

--- a/sources/nodeUtils.ts
+++ b/sources/nodeUtils.ts
@@ -7,17 +7,6 @@ export const dynamicRequire: NodeRequire = typeof __non_webpack_require__ !== `u
   ? __non_webpack_require__
   : require;
 
-function getV8CompileCachePath() {
-  return typeof __non_webpack_require__ !== `undefined`
-    ? `./vcc.js`
-    : `corepack/dist/vcc.js`;
-}
-
-export function registerV8CompileCache() {
-  const vccPath = getV8CompileCachePath();
-  dynamicRequire(vccPath);
-}
-
 /**
  * Loads a module as a main module, enabling the `require.main === module` pattern.
  */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ module.exports = {
   target: `node`,
   entry: {
     [`corepack`]: `./sources/_entryPoint.ts`,
-    [`vcc`]: `v8-compile-cache`,
   },
   output: {
     libraryTarget: `commonjs`,


### PR DESCRIPTION
After the changes in https://github.com/nodejs/corepack/pull/97 we no longer need a path to `v8-compile-cache` so we can just import it normally.