### PR TITLE
chore: fix linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+.yarn
+dist
+shims
+.pnp.*

--- a/genlist.ts
+++ b/genlist.ts
@@ -9,4 +9,3 @@ lines.sort((a, b) => {
 
 for (const version of lines)
   console.log(`"${version}": "${process.argv[2]}",`);
-

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
   "scripts": {
     "build": "rm -rf dist shims && webpack && ts-node ./mkshims.ts",
     "corepack": "ts-node ./sources/_entryPoint.ts",
-    "lint": "yarn eslint",
+    "lint": "eslint .",
     "prepack": "yarn build",
     "postpack": "rm -rf dist shims",
     "typecheck": "tsc --noEmit",
-    "test": "yarn jest"
+    "test": "jest"
   },
   "files": [
     "dist",

--- a/sources/commands/Disable.ts
+++ b/sources/commands/Disable.ts
@@ -3,8 +3,8 @@ import fs                                                                from 'f
 import path                                                              from 'path';
 import which                                                             from 'which';
 
-import type { NodeError }                                                from '../nodeUtils';
 import {Context}                                                         from '../main';
+import type {NodeError}                                                  from '../nodeUtils';
 import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types';
 
 export class DisableCommand extends Command<Context> {

--- a/sources/fsUtils.ts
+++ b/sources/fsUtils.ts
@@ -1,5 +1,5 @@
-import { rm } from "fs/promises";
+import {rm} from 'fs/promises';
 
 export async function rimraf(path: string) {
-  return rm(path, { recursive: true, force: true });
+  return rm(path, {recursive: true, force: true});
 }

--- a/tests/recordRequests.js
+++ b/tests/recordRequests.js
@@ -39,7 +39,7 @@ switch (process.env.NOCK_ENV || ``) {
           req.rawHeaders = filterHeaders(req.rawHeaders);
 
       const serialized = v8.serialize(nockCallObjects);
-      fs.mkdirSync(path.dirname(getNockFile()), { recursive: true });
+      fs.mkdirSync(path.dirname(getNockFile()), {recursive: true});
       fs.writeFileSync(getNockFile(), serialized);
     });
     break;


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `lint` script doesn't match any files.

**How did you fix it?**

Updated it to match all files and then linted them.

Depends on https://github.com/nodejs/corepack/pull/222 which works around https://github.com/arcanis/eslint-plugin-arca/issues/26