### PR TITLE
build: enable production mode

### DIFF
--- a/mkshims.ts
+++ b/mkshims.ts
@@ -6,7 +6,7 @@ import {Engine}                     from './sources/Engine';
 import {SupportedPackageManagerSet} from './sources/types';
 
 function shouldGenerateShim(name: string) {
-  return !name.startsWith(`vendors`);
+  return name !== `chunks`;
 }
 
 const engine = new Engine();

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "semver": "^7.1.3",
     "supports-color": "^9.0.0",
     "tar": "^6.0.1",
-    "terser-webpack-plugin": "^5.1.2",
     "ts-loader": "^9.0.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,7 @@
-const TerserPlugin = require(`terser-webpack-plugin`);
 const webpack = require(`webpack`);
 
 module.exports = {
-  mode: `development`,
+  mode: `production`,
   devtool: false,
   target: `node`,
   entry: {
@@ -10,6 +9,7 @@ module.exports = {
   },
   output: {
     libraryTarget: `commonjs`,
+    chunkFilename: `chunks/[name].cjs`,
   },
   resolve: {
     extensions: [`.ts`, `.js`],
@@ -33,11 +33,7 @@ module.exports = {
     assetsSort: `!size`,
   },
   optimization: {
-    minimizer: [
-      new TerserPlugin({
-        extractComments: false,
-      }),
-    ],
+    minimize: false,
   },
   plugins: [
     new webpack.BannerPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2279,7 +2279,6 @@ __metadata:
     semver: "npm:^7.1.3"
     supports-color: "npm:^9.0.0"
     tar: "npm:^6.0.1"
-    terser-webpack-plugin: "npm:^5.1.2"
     ts-loader: "npm:^9.0.0"
     ts-node: "npm:^10.0.0"
     typescript: "npm:^4.3.2"
@@ -5756,7 +5755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.1.2, terser-webpack-plugin@npm:^5.1.3":
+"terser-webpack-plugin@npm:^5.1.3":
   version: 5.3.6
   resolution: "terser-webpack-plugin@npm:5.3.6"
   dependencies:


### PR DESCRIPTION
**What's the problem this PR addresses?**

Corepack is built in Webpack's development mode which causes Webpack to output files with long filenames.

Fixes https://github.com/nodejs/corepack/issues/130

**How did you fix it?**

Change it to build in production mode but disable minimizing so the code is still somewhat readable.

The bundle size also improved a bit:
```diff
$ du -s dist
- 2434    dist
+ 2170    dist
```