### PR TITLE
chore: add `engines.node` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/nodejs/corepack.git"
   },
+  "engines": {
+    "node": ">=14.14.0"
+  },
   "license": "MIT",
   "packageManager": "yarn@4.0.0-rc.15+sha224.7fa5c1d1875b041cea8fcbf9a364667e398825364bf5c5c8cd5f6601",
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,12 +7,12 @@
     "moduleResolution": "node",
     "noEmit": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["dom", "es2017", "esnext.asynciterable"],
+    "lib": ["ES2020"],
     "module": "commonjs",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2017"
+    "target": "ES2020"
   },
   "ts-node": {
     "transpileOnly": true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
         loader: `ts-loader`,
         options: {
           compilerOptions: {
-            module: `es2020`,
+            module: `ES2020`,
             noEmit: false,
           },
         },


### PR DESCRIPTION
**What's the problem this PR addresses?**

[v0.11.0](https://github.com/nodejs/corepack/releases/tag/v0.11.0) (specifically https://github.com/nodejs/corepack/pull/100) dropped support for Node.js v12 and raised the bar to Node.js v14.14.0 due to https://github.com/nodejs/corepack/blob/82a6715702ac49687aa8b731efb5971bcdeac0a3/sources/fsUtils.ts#L4 (https://nodejs.org/dist/latest-v18.x/docs/api/fs.html#fspromisesrmpath-options) but this wasn't written down as far as I can tell.

Addresses https://github.com/nodejs/corepack/pull/100#pullrequestreview-945341129

**How did you fix it?**

Added `engines.node` to `package.json` to document the minimum version.