### PR TITLE
chore: Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*
-
-      - name: Get the Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{steps.yarn-cache-dir-path.outputs.dir}}
-          key: ${{runner.os}}-yarn-${{hashFiles('**/yarn.lock')}}
-          restore-keys: |
-            ${{runner.os}}-yarn-
+          cache: yarn
 
       - run: corepack yarn install --immutable
 
@@ -63,17 +53,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node}}.x
-
-      - name: Get the Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{steps.yarn-cache-dir-path.outputs.dir}}
-          key: ${{runner.os}}-yarn-${{hashFiles('**/yarn.lock')}}
-          restore-keys: |
-            ${{runner.os}}-yarn-
+          cache: yarn
 
       - run: corepack yarn install --immutable
       - run: corepack yarn build # We need the stubs to run the tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,17 +30,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*
-
-      - name: Get the Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{steps.yarn-cache-dir-path.outputs.dir}}
-          key: ${{runner.os}}-yarn-${{hashFiles('**/yarn.lock')}}
-          restore-keys: |
-            ${{runner.os}}-yarn-
+          cache: yarn
 
       - name: Publish to the npm registry
         run: |

--- a/.github/workflows/update-nock-files.yml
+++ b/.github/workflows/update-nock-files.yml
@@ -26,17 +26,7 @@ jobs:
           # Let's use the oldest version supported to be sure the V8
           # serialization is compatible with all supported versions.
           node-version: 14.x
-
-      - name: Get the Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{steps.yarn-cache-dir-path.outputs.dir}}
-          key: ${{runner.os}}-yarn-${{hashFiles('**/yarn.lock')}}
-          restore-keys: |
-            ${{runner.os}}-yarn-
+          cache: yarn
 
       - run: corepack yarn install --immutable
       - run: corepack yarn build # We need the stubs to run the tests


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yaml
- uses: actions/setup-node@v3
  with:
    node-version: lts/*

- name: Get yarn cache directory path
  id: yarn-cache-dir-path
  run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"

- uses: actions/cache@v3
  with:
    path: ${{steps.yarn-cache-dir-path.outputs.dir}}
    key: ${{runner.os}}-yarn-${{hashFiles('**/yarn.lock')}}
    restore-keys: |
      ${{runner.os}}-yarn-
```

### TO-BE

```yml
- uses: actions/setup-node@v3
  with:
    node-version: lts/*
    cache: yarn
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)