### PR TITLE
chore: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
 
       - name: Get the Yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
+        run: echo "dir=$(corepack yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - uses: actions/cache@v3
         with:
@@ -66,7 +67,8 @@ jobs:
 
       - name: Get the Yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
+        run: echo "dir=$(corepack yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Get the Yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
+        run: echo "dir=$(corepack yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/update-nock-files.yml
+++ b/.github/workflows/update-nock-files.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Get the Yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
+        run: echo "dir=$(corepack yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - uses: actions/cache@v3
         with:
@@ -50,7 +51,8 @@ jobs:
 
       - name: Check if anything has changed
         id: contains-changes
-        run: echo "::set-output name=result::$(git --no-pager diff --quiet -- tests/nock || echo "yes")"
+        run: echo "result=$(git --no-pager diff --quiet -- tests/nock || echo "yes")" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Commit changes
         if: ${{ steps.contains-changes.outputs.result == 'yes' }}


### PR DESCRIPTION
## Description

Resolve #233 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: echo "::set-output name=result::$(git --no-pager diff --quiet -- tests/nock || echo "yes")"
```

```yml
run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)""
```

**TO-BE**

```yml
run: echo "result=$(git --no-pager diff --quiet -- tests/nock || echo "yes")" >> $GITHUB_OUTPUT
shell: bash
```

```yml
run: echo "dir=$(corepack yarn config get cacheFolder)"" >> $GITHUB_OUTPUT
shell: bash
```
