### PR TITLE
Add `"exports"` to the `package.json` to make self-referencing import…

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "engines": {
     "node": ">=14.14.0"
   },
+  "exports": {
+    "./package.json": "./package.json"
+  },
   "license": "MIT",
   "packageManager": "yarn@4.0.0-rc.15+sha224.7fa5c1d1875b041cea8fcbf9a364667e398825364bf5c5c8cd5f6601",
   "devDependencies": {

--- a/tests/_runCli.ts
+++ b/tests/_runCli.ts
@@ -1,5 +1,6 @@
 import {PortablePath, npath} from '@yarnpkg/fslib';
 import {spawn}               from 'child_process';
+import {dirname, join}       from 'path';
 
 export async function runCli(cwd: PortablePath, argv: Array<string>): Promise<{exitCode: number | null, stdout: string, stderr: string}> {
   const out: Array<Buffer> = [];
@@ -8,7 +9,7 @@ export async function runCli(cwd: PortablePath, argv: Array<string>): Promise<{e
   return new Promise((resolve, reject) => {
     if (process.env.RUN_CLI_ID)
       (process.env.RUN_CLI_ID as any)++;
-    const child = spawn(process.execPath, [`--no-warnings`, `-r`, require.resolve(`./recordRequests.js`), require.resolve(`corepack/dist/corepack.js`), ...argv], {
+    const child = spawn(process.execPath, [`--no-warnings`, `-r`, require.resolve(`./recordRequests.js`), join(dirname(require.resolve(`corepack/package.json`)), `dist/corepack.js`), ...argv], {
       cwd: npath.fromPortablePath(cwd),
       env: process.env,
       stdio: `pipe`,

--- a/tests/_runCli.ts
+++ b/tests/_runCli.ts
@@ -1,6 +1,5 @@
 import {PortablePath, npath} from '@yarnpkg/fslib';
 import {spawn}               from 'child_process';
-import {dirname, join}       from 'path';
 
 export async function runCli(cwd: PortablePath, argv: Array<string>): Promise<{exitCode: number | null, stdout: string, stderr: string}> {
   const out: Array<Buffer> = [];
@@ -9,7 +8,7 @@ export async function runCli(cwd: PortablePath, argv: Array<string>): Promise<{e
   return new Promise((resolve, reject) => {
     if (process.env.RUN_CLI_ID)
       (process.env.RUN_CLI_ID as any)++;
-    const child = spawn(process.execPath, [`--no-warnings`, `-r`, require.resolve(`./recordRequests.js`), join(dirname(require.resolve(`corepack/package.json`)), `dist/corepack.js`), ...argv], {
+    const child = spawn(process.execPath, [`--no-warnings`, `-r`, require.resolve(`./recordRequests.js`), require.resolve(`../dist/corepack.js`), ...argv], {
       cwd: npath.fromPortablePath(cwd),
       env: process.env,
       stdio: `pipe`,


### PR DESCRIPTION
…s work

I'm getting the following error, probably due to the switch to ESBuild (Webpack used to embed the JSON info in the JS file):

```
Internal Error: Cannot find module 'corepack/package.json'
Require stack:
- /Users/duhamean/Documents/node/deps/corepack/dist/corepack.js
Require stack:
- /Users/duhamean/Documents/node/deps/corepack/dist/corepack.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1060:15)
    at Function.resolve (node:internal/modules/helpers:118:19)
    at runVersion (…/node/deps/corepack/dist/corepack.js:44173:68)
```

This should fix it for me, but I'm unsure about others, maybe a better fix would be to embed the version string in the JS file? //cc @merceyz 