### PR TITLE
refactor: separate library and CLI entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   },
   "scripts": {
     "build": "rm -rf dist shims && run build:bundle && ts-node ./mkshims.ts",
-    "build:bundle": "esbuild ./sources/_entryPoint.ts --bundle --platform=node --target=node14.14.0 --external:corepack --outfile='./dist/corepack.js' --resolve-extensions='.ts,.mjs,.js'",
-    "corepack": "ts-node ./sources/_entryPoint.ts",
+    "build:bundle": "esbuild ./sources/_lib.ts --bundle --platform=node --target=node14.14.0 --external:corepack --outfile='./dist/lib/corepack.cjs' --resolve-extensions='.ts,.mjs,.js'",
+    "corepack": "ts-node ./sources/_cli.ts",
     "lint": "eslint .",
     "prepack": "yarn build",
     "postpack": "rm -rf dist shims",

--- a/sources/_cli.ts
+++ b/sources/_cli.ts
@@ -1,0 +1,3 @@
+import {runMain} from './main';
+
+runMain(process.argv.slice(2));

--- a/sources/_entryPoint.ts
+++ b/sources/_entryPoint.ts
@@ -1,8 +1,0 @@
-#!/usr/bin/env node
-import {runMain} from './main';
-
-// Used by the generated shims
-export {runMain};
-
-if (process.mainModule === module)
-  runMain(process.argv.slice(2));

--- a/sources/_lib.ts
+++ b/sources/_lib.ts
@@ -1,0 +1,1 @@
+export {runMain} from './main';


### PR DESCRIPTION
**What's the problem this PR addresses?**

The entry point for the Corepack CLI and the (internal) API is the same file forcing the use of `process.mainModule === module` to check which one should be used.

**How did you fix it?**

Create two separate entry points, one for the CLI and one for the API.