### PR TITLE
Updating DNS troubleshooting to mention ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ network interaction.
 There are a wide variety of networking issues that can occur while running `corepack` commands. Things to check:
 
 - Make sure your network connection is active.
-- Make sure the host for your request can be resolved by your DNS; try using `curl [URL]` (ipv4) and `curl -6 [URL]` (ipv6) from your shell.
+- Make sure the host for your request can be resolved by your DNS; try using
+  `curl [URL]` (ipv4) and `curl -6 [URL]` (ipv6) from your shell.
 - Check your proxy settings (see [Environment Variables](#environment-variables)).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ network interaction.
 There are a wide variety of networking issues that can occur while running `corepack` commands. Things to check:
 
 - Make sure your network connection is active.
-- Make sure the host for your request can be resolved by your DNS; try using `curl [URL]` from your shell.
+- Make sure the host for your request can be resolved by your DNS; try using `curl [URL]` (ipv4) and `curl -6 [URL]` (ipv6) from your shell.
 - Check your proxy settings (see [Environment Variables](#environment-variables)).
 
 ## Contributing


### PR DESCRIPTION
This issue is more widespread than I initially thought and some issues arise directly from DNS resolution of ipv6 domains, so I wanted to update the docs to call that out specifically