### PR TITLE
fix: disable `v8-compile-cache` when using `npm@>=9.7.0`

### DIFF
--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -169,7 +169,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
 /**
  * Loads the binary, taking control of the current process.
  */
-export async function runVersion(installSpec: { location: string, spec: PackageManagerSpec }, binName: string, args: Array<string>): Promise<void> {
+export async function runVersion(locator: Locator, installSpec: { location: string, spec: PackageManagerSpec }, binName: string, args: Array<string>): Promise<void> {
   let binPath: string | null = null;
   if (Array.isArray(installSpec.spec.bin)) {
     if (installSpec.spec.bin.some(bin => bin === binName)) {
@@ -191,8 +191,12 @@ export async function runVersion(installSpec: { location: string, spec: PackageM
   if (!binPath)
     throw new Error(`Assertion failed: Unable to locate path for bin '${binName}'`);
 
-  // @ts-expect-error - No types
-  await import(`v8-compile-cache`);
+  // Node.js segfaults when using npm@>=9.7.0 and v8-compile-cache
+  // $ docker run -it node:20.3.0-slim corepack npm@9.7.1 --version
+  // [SIGSEGV]
+  if (locator.name !== `npm` || semver.lt(locator.reference, `9.7.0`))
+    // @ts-expect-error - No types
+    await import(`v8-compile-cache`);
 
   // We load the binary into the current process,
   // while making it think it was spawned.

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -85,7 +85,7 @@ async function executePackageManagerRequest({packageManager, binaryName, binaryV
 
   const installSpec = await context.engine.ensurePackageManager(resolved);
 
-  return await corepackUtils.runVersion(installSpec, binaryName, args);
+  return await corepackUtils.runVersion(resolved, installSpec, binaryName, args);
 }
 
 export async function runMain(argv: Array<string>) {


### PR DESCRIPTION
Node.js segfaults when using `npm@>=9.7.0` and `v8-compile-cache`
```console
$ docker run -it node:20.3.0-slim corepack npm@9.7.1 --version
[SIGSEGV]
```