### PR TITLE
feat: allow fallback to `application/json` for custom registries

### DIFF
--- a/sources/npmRegistryUtils.ts
+++ b/sources/npmRegistryUtils.ts
@@ -6,7 +6,7 @@ import * as httpUtils        from './httpUtils';
 // load abbreviated metadata as that's all we need for these calls
 // see: https://github.com/npm/registry/blob/cfe04736f34db9274a780184d1cdb2fb3e4ead2a/docs/responses/package-metadata.md
 export const DEFAULT_HEADERS: OutgoingHttpHeaders = {
-  [`Accept`]: `application/vnd.npm.install-v1+json`,
+  [`Accept`]: `application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8`,
 };
 export const DEFAULT_NPM_REGISTRY_URL = `https://registry.npmjs.org`;
 


### PR DESCRIPTION
Hello! 👋🏼 

I just ran into an issue where our custom registry doesn't support the `Accept` header value of `application/vnd.npm.install-v1+json`. By providing a fallback to `application/json`, `corepack` can support custom registries that don't support the `application/vnd.npm.install-v1+json` value.

I followed the [article linked in the comments above this code change](https://github.com/npm/registry/blob/cfe04736f34db9274a780184d1cdb2fb3e4ead2a/docs/responses/package-metadata.md) where it is suggested to use `application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*` for fallback. I opted to drop the `*/*` since this is a json fetch implementation but feel free to change it. 

This was also referenced in #296 where @arcanis mentioned this would likely be fine.