### PR TITLE
Fallbacks to npm when COREPACK_NPM_REGISTRY is set

### DIFF
--- a/config.json
+++ b/config.json
@@ -143,6 +143,10 @@
               "versions": "tags"
             }
           },
+          "npmRegistry": {
+            "type": "npm",
+            "package": "@yarnpkg/cli-dist"
+          },
           "commands": {
             "use": [
               "yarn",

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -156,7 +156,10 @@ export class Engine {
       const ranges = Object.keys(definition.ranges);
       const tagRange = ranges[ranges.length - 1];
 
-      const tags = await corepackUtils.fetchAvailableTags(definition.ranges[tagRange].registry);
+      const packageManagerSpec = definition.ranges[tagRange];
+      const registry = corepackUtils.getRegistryFromPackageManagerSpec(packageManagerSpec);
+
+      const tags = await corepackUtils.fetchAvailableTags(registry);
       if (!Object.prototype.hasOwnProperty.call(tags, descriptor.range))
         throw new UsageError(`Tag not found (${descriptor.range})`);
 
@@ -178,7 +181,10 @@ export class Engine {
       return {name: finalDescriptor.name, reference: finalDescriptor.range};
 
     const versions = await Promise.all(Object.keys(definition.ranges).map(async range => {
-      const versions = await corepackUtils.fetchAvailableVersions(definition.ranges[range].registry);
+      const packageManagerSpec = definition.ranges[range];
+      const registry = corepackUtils.getRegistryFromPackageManagerSpec(packageManagerSpec);
+
+      const versions = await corepackUtils.fetchAvailableVersions(registry);
       return versions.filter(version => semverUtils.satisfiesWithPrereleases(version, finalDescriptor.range));
     }));
 

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -14,6 +14,12 @@ import * as nodeUtils                                          from './nodeUtils
 import * as npmRegistryUtils                                   from './npmRegistryUtils';
 import {RegistrySpec, Descriptor, Locator, PackageManagerSpec} from './types';
 
+export function getRegistryFromPackageManagerSpec(spec: PackageManagerSpec) {
+  return process.env.COREPACK_NPM_REGISTRY
+    ? spec.npmRegistry ?? spec.registry
+    : spec.registry;
+}
+
 export async function fetchLatestStableVersion(spec: RegistrySpec): Promise<string> {
   switch (spec.type) {
     case `npm`: {

--- a/sources/types.ts
+++ b/sources/types.ts
@@ -47,6 +47,7 @@ export interface PackageManagerSpec {
   url: string;
   bin: BinSpec | BinList;
   registry: RegistrySpec;
+  npmRegistry?: NpmRegistrySpec;
   commands?: {
     use?: Array<string>;
   };


### PR DESCRIPTION
It's been mentioned a couple of times that Yarn publishing its versions on its own was inconvenient for people using private npm mirrors. I'd prefer to keep using our store by default, but it makes sense to offer a way to fallback to the npm store when requested. This diff changes the logic so that we use the `@yarnpkg/cli-dist` package when the `COREPACK_NPM_REGISTRY` variable is set. It should be backward-compatible, since the `registry` field is still the same.

Fixes #337
