### PR TITLE
Switches Yarn to the "aliases" field

### DIFF
--- a/config.json
+++ b/config.json
@@ -139,7 +139,7 @@
             "type": "url",
             "url": "https://repo.yarnpkg.com/tags",
             "fields": {
-              "tags": "latest",
+              "tags": "aliases",
               "versions": "tags"
             }
           },


### PR DESCRIPTION
I added a new `aliases` field to https://repo.yarnpkg.com/tags which contain all of `stable`, `canary`, and `latest`. We can use this field in the new configuration so that we support `latest` without changing anything to whatever may be relying on the content of the `latest` field.