### PR TITLE
feat: Support redirections

### DIFF
--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -17,7 +17,7 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
       const request: ClientRequest = https.get(url, {...options, agent: proxyAgent}, response => {
         const statusCode = response.statusCode;
 
-        if ([301, 302, 307, 308].includes(statusCode as number))
+        if ([301, 302, 307, 308].includes(statusCode as number) && response.headers.location)
           return createRequest(response.headers.location as string);
 
         if (statusCode != null && statusCode >= 200 && statusCode < 300)

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -16,7 +16,7 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
     const creatRequest = (url: string) => https.get(url, {...options, agent: proxyAgent}, response => {
       const statusCode = response.statusCode;
 
-      if (statusCode === 301 || statusCode === 302)
+      if ([301, 302, 307, 308].includes(statusCode))
         return creatRequest(response.headers.location);
 
       if (statusCode != null && statusCode >= 200 && statusCode < 300)

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -13,11 +13,11 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
   const proxyAgent = new ProxyAgent();
 
   return new Promise<IncomingMessage>((resolve, reject) => {
-    const creatRequest = (url: string) => https.get(url, {...options, agent: proxyAgent}, response => {
+    const createRequest = (url: string) => https.get(url, {...options, agent: proxyAgent}, response => {
       const statusCode = response.statusCode;
 
       if ([301, 302, 307, 308].includes(statusCode))
-        return creatRequest(response.headers.location);
+        return createRequest(response.headers.location);
 
       if (statusCode != null && statusCode >= 200 && statusCode < 300)
         return resolve(response);
@@ -25,7 +25,7 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
       return reject(new Error(`Server answered with HTTP ${statusCode} when performing the request to ${url}; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting`));
     });
 
-    const request = creatRequest(url);
+    const request = createRequest(url);
 
     request.on(`error`, err => {
       reject(new Error(`Error when performing the request to ${url}; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting`));

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -1,6 +1,6 @@
-import {UsageError}      from 'clipanion';
-import {RequestOptions}  from 'https';
-import {IncomingMessage} from 'http';
+import {UsageError}                     from 'clipanion';
+import {RequestOptions}                 from 'https';
+import {IncomingMessage, ClientRequest} from 'http';
 
 export async function fetchUrlStream(url: string, options: RequestOptions = {}) {
   if (process.env.COREPACK_ENABLE_NETWORK === `0`)
@@ -13,23 +13,25 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
   const proxyAgent = new ProxyAgent();
 
   return new Promise<IncomingMessage>((resolve, reject) => {
-    const createRequest = (url: string) => https.get(url, {...options, agent: proxyAgent}, response => {
-      const statusCode = response.statusCode;
+    const createRequest = (url: string) => {
+      const request: ClientRequest = https.get(url, {...options, agent: proxyAgent}, response => {
+        const statusCode = response.statusCode;
 
-      if ([301, 302, 307, 308].includes(statusCode))
-        return createRequest(response.headers.location);
+        if ([301, 302, 307, 308].includes(statusCode as number))
+          return createRequest(response.headers.location as string);
 
-      if (statusCode != null && statusCode >= 200 && statusCode < 300)
-        return resolve(response);
+        if (statusCode != null && statusCode >= 200 && statusCode < 300)
+          return resolve(response);
 
-      return reject(new Error(`Server answered with HTTP ${statusCode} when performing the request to ${url}; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting`));
-    });
+        return reject(new Error(`Server answered with HTTP ${statusCode} when performing the request to ${url}; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting`));
+      });
 
-    const request = createRequest(url);
+      request.on(`error`, err => {
+        reject(new Error(`Error when performing the request to ${url}; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting`));
+      });
+    };
 
-    request.on(`error`, err => {
-      reject(new Error(`Error when performing the request to ${url}; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting`));
-    });
+    createRequest(url);
   });
 }
 

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -13,13 +13,19 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
   const proxyAgent = new ProxyAgent();
 
   return new Promise<IncomingMessage>((resolve, reject) => {
-    const request = https.get(url, {...options, agent: proxyAgent}, response => {
+    const creatRequest = (url: string) => https.get(url, {...options, agent: proxyAgent}, response => {
       const statusCode = response.statusCode;
+
+      if (statusCode === 301 || statusCode === 302)
+        return creatRequest(response.headers.location);
+
       if (statusCode != null && statusCode >= 200 && statusCode < 300)
         return resolve(response);
 
       return reject(new Error(`Server answered with HTTP ${statusCode} when performing the request to ${url}; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting`));
     });
+
+    const request = creatRequest(url);
 
     request.on(`error`, err => {
       reject(new Error(`Error when performing the request to ${url}; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting`));

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -14,7 +14,7 @@ describe(`http utils fetchUrlStream`, () => {
     const errorCallbacks: Array<(err: string) => void> = [];
 
     if ([301, 302, 307, 308].includes(+statusCode)) {
-      const redirectCode = parsedUrl.searchParams.get(`redirectCode`) as string;
+      const redirectCode = parsedURL.searchParams.get(`redirectCode`)!;
       // mock response.headers.location
       Reflect.set(response, `headers`, {location: getUrl(redirectCode)});
     }

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -57,7 +57,7 @@ describe(`http utils fetchUrlStream`, () => {
     expect(httpsGetFn).toHaveBeenCalledTimes(2);
   });
 
-  it(`bed response`, async () => {
+  it(`bad response`, async () => {
     await expect(fetchUrlStream(getUrl(300))).rejects.toThrowError();
     await expect(fetchUrlStream(getUrl(199))).rejects.toThrowError();
   });

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -16,7 +16,7 @@ describe(`http utils fetchUrlStream`, () => {
     if ([301, 302, 307, 308].includes(+statusCode)) {
       const redirectCode = parsedURL.searchParams.get(`redirectCode`)!;
       // mock response.headers.location
-      Reflect.set(response, `headers`, {location: getUrl(redirectCode)});
+      if (redirectCode) Reflect.set(response, `headers`, {location: getUrl(redirectCode)});
     }
 
     // handle request.on('error', err => ...)

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -8,7 +8,7 @@ describe(`http utils fetchUrlStream`, () => {
     `https://registry.example.org/answered/${statusCode}${redirectCode ? `?redirectCode=${redirectCode}` : ``}`;
 
   const httpsGetFn = jest.fn((url: string, _, callback: (response: any) => void) => {
-    const parsedUrl = new URL(url);
+    const parsedURL = new URL(url);
     const {1: statusCode} = parsedUrl.pathname.match(/\/(\d+|error)/) as Array<string>;
     const response = {url, statusCode: +statusCode};
     const errorCallbacks: Array<(err: string) => void> = [];

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -76,7 +76,7 @@ describe(`http utils fetchUrlStream`, () => {
     expect(httpsGetFn).toHaveBeenCalledTimes(4);
   });
 
-  it(`redirection with bed response`, async () => {
+  it(`redirection with bad response`, async () => {
     await expect(fetchUrlStream(getUrl(301, 300))).rejects.toThrowError();
     await expect(fetchUrlStream(getUrl(308, 199))).rejects.toThrowError();
   });

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -16,7 +16,9 @@ describe(`http utils fetchUrlStream`, () => {
     if ([301, 302, 307, 308].includes(+statusCode)) {
       const redirectCode = parsedURL.searchParams.get(`redirectCode`)!;
       // mock response.headers.location
-      if (redirectCode) Reflect.set(response, `headers`, {location: getUrl(redirectCode)});
+      if (redirectCode) {
+        Reflect.set(response, `headers`, {location: getUrl(redirectCode)});
+      }
     }
 
     // handle request.on('error', err => ...)

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -9,7 +9,7 @@ describe(`http utils fetchUrlStream`, () => {
 
   const httpsGetFn = jest.fn((url: string, _, callback: (response: any) => void) => {
     const parsedURL = new URL(url);
-    const {1: statusCode} = parsedUrl.pathname.match(/\/(\d+|error)/) as Array<string>;
+    const statusCode = parsedURL.pathname.slice(parsedURL.pathname.lastIndexOf(`/`) + 1);
     const response = {url, statusCode: +statusCode};
     const errorCallbacks: Array<(err: string) => void> = [];
 

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -79,6 +79,8 @@ describe(`http utils fetchUrlStream`, () => {
   it(`redirection with bad response`, async () => {
     await expect(fetchUrlStream(getUrl(301, 300))).rejects.toThrowError();
     await expect(fetchUrlStream(getUrl(308, 199))).rejects.toThrowError();
+    await expect(fetchUrlStream(getUrl(301, 302))).rejects.toThrowError();
+    await expect(fetchUrlStream(getUrl(307))).rejects.toThrowError();
   });
 
   it(`rejects with error`, async () => {

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -1,0 +1,91 @@
+import {jest, describe, beforeEach, beforeAll, it, expect} from '@jest/globals';
+
+import {fetchUrlStream}                                    from '../sources/httpUtils';
+
+
+describe(`http utils fetchUrlStream`, () => {
+  const getUrl = (statusCode: number | string, redirectCode?: number | string) =>
+    `https://registry.example.org/answered/${statusCode}${redirectCode ? `?redirectCode=${redirectCode}` : ``}`;
+
+  const httpsGetFn = jest.fn((url: string, _, callback: (response: any) => void) => {
+    const parsedUrl = new URL(url);
+    const {1: statusCode} = parsedUrl.pathname.match(/\/(\d+|error)/) as Array<string>;
+    const response = {url, statusCode: +statusCode};
+    const errorCallbacks: Array<(err: string) => void> = [];
+
+    if ([301, 302, 307, 308].includes(+statusCode)) {
+      const redirectCode = parsedUrl.searchParams.get(`redirectCode`) as string;
+      // mock response.headers.location
+      Reflect.set(response, `headers`, {location: getUrl(redirectCode)});
+    }
+
+    // handle request.on('error', err => ...)
+    if (statusCode === `error`)
+      process.nextTick(() => errorCallbacks.forEach(cb => cb(`Test internal error`)));
+    else
+      callback(response);
+
+    return {
+      on: (type: string, callback: (err: string) => void) => {
+        if (type === `error`) {
+          errorCallbacks.push(callback);
+        }
+      },
+    };
+  });
+
+  beforeAll(() => {
+    jest.doMock(`https`, () => ({
+      get: httpsGetFn,
+      Agent: class Agent {},
+    }));
+  });
+
+  beforeEach(() => {
+    httpsGetFn.mockClear();
+  });
+
+  it(`correct response answered statusCode should be >= 200 and < 300`, async () => {
+    await expect(fetchUrlStream(getUrl(200))).resolves.toMatchObject({
+      statusCode: 200,
+    });
+
+    await expect(fetchUrlStream(getUrl(299))).resolves.toMatchObject({
+      statusCode: 299,
+    });
+
+    expect(httpsGetFn).toHaveBeenCalledTimes(2);
+  });
+
+  it(`bed response`, async () => {
+    await expect(fetchUrlStream(getUrl(300))).rejects.toThrowError();
+    await expect(fetchUrlStream(getUrl(199))).rejects.toThrowError();
+  });
+
+  it(`redirection with correct response`, async () => {
+    await expect(fetchUrlStream(getUrl(301, 200))).resolves.toMatchObject({
+      statusCode: 200,
+    });
+
+    expect(httpsGetFn).toHaveBeenCalledTimes(2);
+
+    await expect(fetchUrlStream(getUrl(308, 299))).resolves.toMatchObject({
+      statusCode: 299,
+    });
+
+    expect(httpsGetFn).toHaveBeenCalledTimes(4);
+  });
+
+  it(`redirection with bed response`, async () => {
+    await expect(fetchUrlStream(getUrl(301, 300))).rejects.toThrowError();
+    await expect(fetchUrlStream(getUrl(308, 199))).rejects.toThrowError();
+  });
+
+  it(`rejects with error`, async () => {
+    await expect(fetchUrlStream(getUrl(`error`))).rejects.toThrowError();
+  });
+
+  it(`rejects when redirection with error`, async () => {
+    await expect(fetchUrlStream(getUrl(307, `error`))).rejects.toThrowError();
+  });
+});


### PR DESCRIPTION
Some registries will redirect and return with 302;

It will cause corepack error；
```bash
Internal Error: Server answered with HTTP 302
```

This PR helps redirections supported when a request responds with a 302 or 301 status code.

Associated with:  
https://github.com/nodejs/corepack/issues/302
https://github.com/nodejs/corepack/issues/336
