### PR TITLE
feat!: prompt user before downloading software

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ same major line. Should you need to upgrade to a new major, use an explicit
   not to lookup on the remote registry for the latest version of the selected
   package manager.
 
-- `COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD` can be set to `0` to
+- `COREPACK_ENABLE_DOWNLOAD_PROMPT` can be set to `0` to
   prevent Corepack showing the URL when it needs to download software, or can be
   set to `1` to have the URL shown. By default, when Corepack is called
   explicitly (e.g. `corepack pnpm …`), it is set to `0`; when Corepack is called

--- a/README.md
+++ b/README.md
@@ -224,11 +224,12 @@ same major line. Should you need to upgrade to a new major, use an explicit
   package manager.
 
 - `COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD` can be set to `0` to
-  prevent Corepack from asking for validation before downloading software from
-  the network, or on the contrary set to `1` to force Corepack to ask for
-  explicit consent. By default, Corepack will ask for explicit consent only when
-  Corepack is used implicitly (i.e. `corepack pnpm …` won't ask for explicit
-  consent, `pnpm …` would).
+  prevent Corepack showing the URL when it needs to download software, or can be
+  set to `1` to have the URL shown. By default, when Corepack is called
+  explicitly (e.g. `corepack pnpm …`), it is set to `0`; when Corepack is called
+  implicitely (e.g. `pnpm …`), it is set to `1`.
+  When standard input is a TTY and no CI environment is detected, Corepack will
+  ask for user input before starting the download.
 
 - `COREPACK_ENABLE_NETWORK` can be set to `0` to prevent Corepack from accessing
   the network (in which case you'll be responsible for hydrating the package

--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ same major line. Should you need to upgrade to a new major, use an explicit
   not to lookup on the remote registry for the latest version of the selected
   package manager.
 
+- `COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD` can be set to `0` to
+  prevent Corepack from asking for validation before downloading software from
+  the network, or on the contrary set to `1` to force Corepack to ask for
+  explicit consent. By default, Corepack will ask for explicit consent only when
+  Corepack is used implicitly (i.e. `corepack pnpm …` won't ask for explicit
+  consent, `pnpm …` would).
+
 - `COREPACK_ENABLE_NETWORK` can be set to `0` to prevent Corepack from accessing
   the network (in which case you'll be responsible for hydrating the package
   manager versions that will be required for the projects you'll run, using

--- a/mkshims.ts
+++ b/mkshims.ts
@@ -21,7 +21,7 @@ async function main() {
   const corepackPath = path.join(distDir, `corepack.js`);
   fs.writeFileSync(corepackPath, [
     `#!/usr/bin/env node`,
-    `process.env.COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD??='0';`,
+    `process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='0';`,
     `require('./lib/corepack.cjs').runMain(process.argv.slice(2));`,
   ].join(`\n`));
   fs.chmodSync(corepackPath, 0o755);
@@ -33,7 +33,7 @@ async function main() {
       const entryPath = path.join(distDir, `${binaryName}.js`);
       const entryScript = [
         `#!/usr/bin/env node`,
-        `process.env.COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD??='1'`,
+        `process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='1'`,
         `require('./lib/corepack.cjs').runMain(['${binaryName}', ...process.argv.slice(2)]);`,
       ].join(`\n`);
 

--- a/mkshims.ts
+++ b/mkshims.ts
@@ -21,6 +21,7 @@ async function main() {
   const corepackPath = path.join(distDir, `corepack.js`);
   fs.writeFileSync(corepackPath, [
     `#!/usr/bin/env node`,
+    `process.env.COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD??='0'`,
     `require('./lib/corepack.cjs').runMain(process.argv.slice(2));`,
   ].join(`\n`));
   fs.chmodSync(corepackPath, 0o755);
@@ -32,6 +33,7 @@ async function main() {
       const entryPath = path.join(distDir, `${binaryName}.js`);
       const entryScript = [
         `#!/usr/bin/env node`,
+        `process.env.COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD??='1'`,
         `require('./lib/corepack.cjs').runMain(['${binaryName}', ...process.argv.slice(2)]);`,
       ].join(`\n`);
 

--- a/mkshims.ts
+++ b/mkshims.ts
@@ -21,7 +21,7 @@ async function main() {
   const corepackPath = path.join(distDir, `corepack.js`);
   fs.writeFileSync(corepackPath, [
     `#!/usr/bin/env node`,
-    `process.env.COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD??='0'`,
+    `process.env.COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD??='0';`,
     `require('./lib/corepack.cjs').runMain(process.argv.slice(2));`,
   ].join(`\n`));
   fs.chmodSync(corepackPath, 0o755);

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -12,6 +12,8 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
 
   const proxyAgent = new ProxyAgent();
 
+  console.log(`Corepack: Fetching ${url}...`);
+
   return new Promise<IncomingMessage>((resolve, reject) => {
     const createRequest = (url: string) => {
       const request: ClientRequest = https.get(url, {...options, agent: proxyAgent}, response => {

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -14,7 +14,7 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
 
   const proxyAgent = new ProxyAgent();
 
-  if (process.env.COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD === `1`) {
+  if (process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT === `1`) {
     console.error(`Corepack is about to download ${url}.`);
     if (stdin.isTTY && !process.env.CI) {
       stderr.write(`\nDo you want to continue? [Y/n] `);

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -14,17 +14,19 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
 
   const proxyAgent = new ProxyAgent();
 
-  if (process.env.COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD !== `0`) {
+  if (process.env.COREPACK_ENABLE_EXPLICIT_VALIDATION_BEFORE_DOWNLOAD === `1`) {
     console.error(`Corepack is about to download ${url}.`);
-    stderr.write(`\nDo you want to continue? [Y/n] `);
-    stdin.resume();
-    const chars = await once(stdin, `data`);
-    stdin.pause();
-    if (
-      chars[0][0] === 0x6e || // n
-      chars[0][0] === 0x4e // N
-    ) {
-      throw new UsageError(`Aborted by the user`);
+    if (stdin.isTTY && !process.env.CI) {
+      stderr.write(`\nDo you want to continue? [Y/n] `);
+      stdin.resume();
+      const chars = await once(stdin, `data`);
+      stdin.pause();
+      if (
+        chars[0][0] === 0x6e || // n
+        chars[0][0] === 0x4e // N
+      ) {
+        throw new UsageError(`Aborted by the user`);
+      }
     }
   }
 


### PR DESCRIPTION
Adds a prompt to let user validate each download . No prompt is shown when the software is already in the cache. The prompt can be opt-in/opt-out using an env variable, by default it's only shown when "not using the `corepack` binary" (i.e. when using the binaries created by `corepack enable`)