### PR TITLE
feat: support http urls

### DIFF
--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -6,7 +6,9 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
   if (process.env.COREPACK_ENABLE_NETWORK === `0`)
     throw new UsageError(`Network access disabled by the environment; can't reach ${url}`);
 
-  const {default: https} = await import(`https`);
+  const {get} = url.startsWith(`http://`)
+    ? await import(`http`)
+    : await import(`https`);
 
   const {ProxyAgent} = await import(`proxy-agent`);
 
@@ -14,7 +16,7 @@ export async function fetchUrlStream(url: string, options: RequestOptions = {}) 
 
   return new Promise<IncomingMessage>((resolve, reject) => {
     const createRequest = (url: string) => {
-      const request: ClientRequest = https.get(url, {...options, agent: proxyAgent}, response => {
+      const request: ClientRequest = get(url, {...options, agent: proxyAgent}, response => {
         const statusCode = response.statusCode;
 
         if ([301, 302, 307, 308].includes(statusCode as number) && response.headers.location)


### PR DESCRIPTION
I use an localhost http npm registry  but corepack always uses the `https` module and errors on `http://` urls. 

I do not handle http to https redirects (https to http), I'm open to suggestions, like explicitly failing or only supporting secure upgrades. 