### PR TITLE
chore(tests): increase timeout to get more green on Windows CI

### DIFF
--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -541,7 +541,7 @@ it(`should support hydrating multiple package managers from cached archives`, as
       delete process.env.COREPACK_ENABLE_NETWORK;
     }
   });
-});
+}, 180_000);
 
 it(`should support running package managers with bin array`, async () => {
   await xfs.mktempPromise(async cwd => {


### PR DESCRIPTION
For some reason this test times out quite frequently on Windows CI. Hopefully if we give it more time to succeed, and we won't need to restart Windows CI as often.