### PR TITLE
feat!: remove old install folder migration

### DIFF
--- a/sources/folderUtils.ts
+++ b/sources/folderUtils.ts
@@ -1,33 +1,12 @@
-import {UsageError}                        from 'clipanion';
-import {existsSync, mkdirSync, renameSync} from 'fs';
-import {homedir, tmpdir}                   from 'os';
-import {join}                              from 'path';
-import process                             from 'process';
+import {UsageError}      from 'clipanion';
+import {mkdirSync}       from 'fs';
+import {homedir, tmpdir} from 'os';
+import {join}            from 'path';
+import process           from 'process';
 
-import type {NodeError}                    from './nodeUtils';
+import type {NodeError}  from './nodeUtils';
 
 export function getInstallFolder() {
-  if (process.env.COREPACK_HOME == null) {
-    // TODO: remove this block on the next major.
-    const oldCorepackDefaultHome = join(homedir(), `.node`, `corepack`);
-    const newCorepackDefaultHome = join(
-      process.env.XDG_CACHE_HOME ??
-        process.env.LOCALAPPDATA ??
-        join(
-          homedir(),
-          process.platform === `win32` ? `AppData/Local` : `.cache`,
-        ),
-      `node/corepack`,
-    );
-    if (
-      existsSync(oldCorepackDefaultHome) &&
-      !existsSync(newCorepackDefaultHome)
-    ) {
-      mkdirSync(newCorepackDefaultHome, {recursive: true});
-      renameSync(oldCorepackDefaultHome, newCorepackDefaultHome);
-    }
-    return newCorepackDefaultHome;
-  }
   return (
     process.env.COREPACK_HOME ??
     join(


### PR DESCRIPTION
Since https://github.com/nodejs/corepack/pull/291 was merged Corepack wont reuse the package managers installed by old Corepack versions so no need to keep the migration.

Ref https://github.com/nodejs/corepack/pull/372#issuecomment-1925471159