### PR TITLE
chore!: remove Node.js 19.x from the range of supported versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/nodejs/corepack.git"
   },
   "engines": {
-    "node": ">=18.17.1"
+    "node": "^18.17.1 | >=20.10.0"
   },
   "exports": {
     "./package.json": "./package.json"


### PR DESCRIPTION
We do not support EOL versions.