### PR TITLE
fix: use valid semver range for `engines.node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/nodejs/corepack.git"
   },
   "engines": {
-    "node": "^18.17.1 | >=20.10.0"
+    "node": "^18.17.1 || >=20.10.0"
   },
   "exports": {
     "./package.json": "./package.json"


### PR DESCRIPTION
The range added in https://github.com/nodejs/corepack/pull/375 isn't valid.