### PR TITLE
fix: do not show download prompt when downloading JSON

### DIFF
--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -4,27 +4,11 @@ import {once}          from 'events';
 import {stderr, stdin} from 'process';
 import {Readable}      from 'stream';
 
-export async function fetch(input: string | URL, init?: RequestInit) {
+async function fetch(input: string | URL, init?: RequestInit) {
   if (process.env.COREPACK_ENABLE_NETWORK === `0`)
     throw new UsageError(`Network access disabled by the environment; can't reach ${input}`);
 
   const agent = await getProxyAgent(input);
-
-  if (process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT === `1`) {
-    console.error(`Corepack is about to download ${input}.`);
-    if (stdin.isTTY && !process.env.CI) {
-      stderr.write(`\nDo you want to continue? [Y/n] `);
-      stdin.resume();
-      const chars = await once(stdin, `data`);
-      stdin.pause();
-      if (
-        chars[0][0] === 0x6e || // n
-        chars[0][0] === 0x4e // N
-      ) {
-        throw new UsageError(`Aborted by the user`);
-      }
-    }
-  }
 
   let response;
   try {
@@ -55,6 +39,22 @@ export async function fetchAsJson(input: string | URL, init?: RequestInit) {
 }
 
 export async function fetchUrlStream(input: string | URL, init?: RequestInit) {
+  if (process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT === `1`) {
+    console.error(`Corepack is about to download ${input}.`);
+    if (stdin.isTTY && !process.env.CI) {
+      stderr.write(`\nDo you want to continue? [Y/n] `);
+      stdin.resume();
+      const chars = await once(stdin, `data`);
+      stdin.pause();
+      if (
+        chars[0][0] === 0x6e || // n
+        chars[0][0] === 0x4e // N
+      ) {
+        throw new UsageError(`Aborted by the user`);
+      }
+    }
+  }
+
   const response = await fetch(input, init);
   const webStream = response.body;
   assert(webStream, `Expected stream to be set`);


### PR DESCRIPTION
JSON data is (supposedly) rather innocuous, it seems unnecessary to have a prompt for those.

Fixes: https://github.com/nodejs/corepack/issues/380