### PR TITLE
Fix Windows malicious file analysis waiting problem

### DIFF
--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -6,6 +6,7 @@ import type {Dir}                                              from 'fs';
 import Module                                                  from 'module';
 import path                                                    from 'path';
 import semver                                                  from 'semver';
+import {setTimeout as setTimeoutPromise}                       from 'timers/promises';
 
 import * as engine                                             from './Engine';
 import * as debugUtils                                         from './debugUtils';
@@ -279,7 +280,7 @@ async function renameUnderWindows(oldPath: fs.PathLike, newPath: fs.PathLike) {
         ) &&
         i < (retries - 1)
       ) {
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await setTimeoutPromise(100);
         continue;
       } else {
         throw err;

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -221,8 +221,13 @@ export async function installVersion(installTarget: string, locator: Locator, {s
           await fs.promises.rename(tmpFolder, installFolder);
           break;
         } catch (err) {
-          if ((err as nodeUtils.NodeError).code === `ENOENT` && i < (retries - 1)) {
-            lastErr = err as nodeUtils.NodeError;
+          if (
+            (
+              (err as nodeUtils.NodeError).code === `ENOENT` ||
+              (err as nodeUtils.NodeError).code === "EPERM"
+            ) &&
+            i < (retries - 1)
+          ) {
             await new Promise(resolve => setTimeout(resolve, 100));
             continue;
           } else {

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -224,7 +224,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
           if (
             (
               (err as nodeUtils.NodeError).code === `ENOENT` ||
-              (err as nodeUtils.NodeError).code === "EPERM"
+              (err as nodeUtils.NodeError).code === `EPERM`
             ) &&
             i < (retries - 1)
           ) {

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -280,7 +280,7 @@ async function renameUnderWindows(oldPath: fs.PathLike, newPath: fs.PathLike) {
         ) &&
         i < (retries - 1)
       ) {
-        await setTimeoutPromise(100);
+        await setTimeoutPromise(100 * 2 ** i);
         continue;
       } else {
         throw err;

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -266,7 +266,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
 }
 
 async function renameUnderWindows(oldPath: fs.PathLike, newPath: fs.PathLike) {
-  // Windows malicious file analysis blocks files after download so we need to wait for file release
+  // Windows malicious file analysis blocks files currently under analysis, so we need to wait for file release
   const retries = 5;
   for (let i = 0; i < retries; i++) {
     try {


### PR DESCRIPTION
Fixes #246

That should fix the problem that windows malicious file analysis blocks the freshly downloaded file.
I couldn't reproduce the error on my side currently, but it should help.