### PR TITLE
Marks `yarn init` as a transparent command

### DIFF
--- a/config.json
+++ b/config.json
@@ -106,6 +106,10 @@
         "commands": [
           [
             "yarn",
+            "init"
+          ],
+          [
+            "yarn",
             "dlx"
           ]
         ]


### PR DESCRIPTION
New projects should use the newest versions when setup. Adding `yarn init` as a transparent command means that people running it will automatically have the `packageManager` field set to `4.1.0+sha...` unless they explicitly opt-out by running `corepack yarn@1 init` instead.

Projects that don't list package managers will still execute Yarn 1.x, and so will other Yarn commands executed from outside any package directory (`yarn config set`, etc).