### PR TITLE
feat: Pins the package manager as it's used for the first time

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ same major line. Should you need to upgrade to a new major, use an explicit
   package manager, and to not update the Last Known Good version when it
   downloads a new version of the same major line.
 
+- `COREPACK_ENABLE_AUTO_PIN` can be set to `0` to prevent Corepack from
+  updating the `packageManager` field when it detects that the local package
+  doesn't list it. In general we recommend to always list a `packageManager`
+  field (which you can easily set through `corepack use [name]@[version]`), as
+  it ensures that your project installs are always deterministic.
+
 - `COREPACK_ENABLE_DOWNLOAD_PROMPT` can be set to `0` to
   prevent Corepack showing the URL when it needs to download software, or can be
   set to `1` to have the URL shown. By default, when Corepack is called

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -264,8 +264,8 @@ export class Engine {
 
             const installSpec = await this.ensurePackageManager(resolved);
 
-            console.error(`! The local project doesn't feature a 'packageManager' field - a new one will be created referencing ${installSpec.locator.name}@${installSpec.locator.reference}.`);
-            console.error(`! For more details about this field, consult the documentation at https://nodejs.org/api/corepack.html`);
+            console.error(`! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing ${installSpec.locator.name}@${installSpec.locator.reference}.`);
+            console.error(`! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager`);
             console.error();
 
             await specUtils.setLocalPackageManager(path.dirname(result.target), installSpec);

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -10,13 +10,21 @@ import defaultConfig                                          from '../config.js
 import * as corepackUtils                                     from './corepackUtils';
 import * as debugUtils                                        from './debugUtils';
 import * as folderUtils                                       from './folderUtils';
+import * as miscUtils                                         from './miscUtils';
 import type {NodeError}                                       from './nodeUtils';
 import * as semverUtils                                       from './semverUtils';
+import * as specUtils                                         from './specUtils';
 import {Config, Descriptor, Locator, PackageManagerSpec}      from './types';
 import {SupportedPackageManagers, SupportedPackageManagerSet} from './types';
 import {isSupportedPackageManager}                            from './types';
 
 export type PreparedPackageManagerInfo = Awaited<ReturnType<Engine[`ensurePackageManager`]>>;
+
+export type PackageManagerRequest = {
+  packageManager: SupportedPackageManagers;
+  binaryName: string;
+  binaryVersion: string | null;
+};
 
 export function getLastKnownGoodFile(flag = `r`) {
   return fs.promises.open(path.join(folderUtils.getCorepackHomeFolder(), `lastKnownGood.json`), flag);
@@ -200,15 +208,132 @@ export class Engine {
       spec,
     });
 
+    const noHashReference = locator.reference.replace(/\+.*/, ``);
+    const fixedHashReference = `${noHashReference}+${packageManagerInfo.hash}`;
+
+    const fixedHashLocator = {
+      name: locator.name,
+      reference: fixedHashReference,
+    };
+
     return {
       ...packageManagerInfo,
-      locator,
+      locator: fixedHashLocator,
       spec,
     };
   }
 
-  async fetchAvailableVersions() {
+  /**
+   * Locates the active project's package manager specification.
+   *
+   * If the specification exists but doesn't match the active package manager,
+   * an error is thrown to prevent users from using the wrong package manager,
+   * which would lead to inconsistent project layouts.
+   *
+   * If the project doesn't include a specification file, we just assume that
+   * whatever the user uses is exactly what they want to use. Since the version
+   * isn't explicited, we fallback on known good versions.
+   *
+   * Finally, if the project doesn't exist at all, we ask the user whether they
+   * want to create one in the current project. If they do, we initialize a new
+   * project using the default package managers, and configure it so that we
+   * don't need to ask again in the future.
+   */
+  async findProjectSpec(initialCwd: string, locator: Locator, {transparent = false}: {transparent?: boolean} = {}): Promise<Descriptor> {
+    // A locator is a valid descriptor (but not the other way around)
+    const fallbackDescriptor = {name: locator.name, range: `${locator.reference}`};
 
+    if (process.env.COREPACK_ENABLE_PROJECT_SPEC === `0`)
+      return fallbackDescriptor;
+
+    if (process.env.COREPACK_ENABLE_STRICT === `0`)
+      transparent = true;
+
+    while (true) {
+      const result = await specUtils.loadSpec(initialCwd);
+
+      switch (result.type) {
+        case `NoProject`:
+          return fallbackDescriptor;
+
+        case `NoSpec`: {
+          const resolved = await this.resolveDescriptor(fallbackDescriptor, {allowTags: true});
+          if (resolved === null)
+            throw new UsageError(`Failed to successfully resolve '${fallbackDescriptor.range}' to a valid ${fallbackDescriptor.name} release`);
+
+          const installSpec = await this.ensurePackageManager(resolved);
+          await specUtils.setLocalPackageManager(path.dirname(result.target), installSpec);
+
+          return fallbackDescriptor;
+        }
+
+        case `Found`: {
+          if (result.spec.name !== locator.name) {
+            if (transparent) {
+              return fallbackDescriptor;
+            } else {
+              throw new UsageError(`This project is configured to use ${result.spec.name}`);
+            }
+          } else {
+            return result.spec;
+          }
+        }
+      }
+    }
+  }
+
+  async executePackageManagerRequest({packageManager, binaryName, binaryVersion}: PackageManagerRequest, {cwd, args}: {cwd: string, args: Array<string>}): Promise<number | void> {
+    let fallbackLocator: Locator = {
+      name: binaryName as SupportedPackageManagers,
+      reference: undefined as any,
+    };
+
+    let isTransparentCommand = false;
+    if (packageManager != null) {
+      const defaultVersion = await this.getDefaultVersion(packageManager);
+      const definition = this.config.definitions[packageManager]!;
+
+      // If all leading segments match one of the patterns defined in the `transparent`
+      // key, we tolerate calling this binary even if the local project isn't explicitly
+      // configured for it, and we use the special default version if requested.
+      for (const transparentPath of definition.transparent.commands) {
+        if (transparentPath[0] === binaryName && transparentPath.slice(1).every((segment, index) => segment === args[index])) {
+          isTransparentCommand = true;
+          break;
+        }
+      }
+
+      const fallbackReference = isTransparentCommand
+        ? definition.transparent.default ?? defaultVersion
+        : defaultVersion;
+
+      fallbackLocator = {
+        name: packageManager,
+        reference: fallbackReference,
+      };
+    }
+
+    let descriptor: Descriptor;
+    try {
+      descriptor = await this.findProjectSpec(cwd, fallbackLocator, {transparent: isTransparentCommand});
+    } catch (err) {
+      if (err instanceof miscUtils.Cancellation) {
+        return 1;
+      } else {
+        throw err;
+      }
+    }
+
+    if (binaryVersion)
+      descriptor.range = binaryVersion;
+
+    const resolved = await this.resolveDescriptor(descriptor, {allowTags: true});
+    if (resolved === null)
+      throw new UsageError(`Failed to successfully resolve '${descriptor.range}' to a valid ${descriptor.name} release`);
+
+    const installSpec = await this.ensurePackageManager(resolved);
+
+    return await corepackUtils.runVersion(resolved, installSpec, binaryName, args);
   }
 
   async resolveDescriptor(descriptor: Descriptor, {allowTags = false, useCache = true}: {allowTags?: boolean, useCache?: boolean} = {}): Promise<Locator | null> {

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -257,12 +257,19 @@ export class Engine {
           return fallbackDescriptor;
 
         case `NoSpec`: {
-          const resolved = await this.resolveDescriptor(fallbackDescriptor, {allowTags: true});
-          if (resolved === null)
-            throw new UsageError(`Failed to successfully resolve '${fallbackDescriptor.range}' to a valid ${fallbackDescriptor.name} release`);
+          if (process.env.COREPACK_ENABLE_AUTO_PIN !== `0`) {
+            const resolved = await this.resolveDescriptor(fallbackDescriptor, {allowTags: true});
+            if (resolved === null)
+              throw new UsageError(`Failed to successfully resolve '${fallbackDescriptor.range}' to a valid ${fallbackDescriptor.name} release`);
 
-          const installSpec = await this.ensurePackageManager(resolved);
-          await specUtils.setLocalPackageManager(path.dirname(result.target), installSpec);
+            const installSpec = await this.ensurePackageManager(resolved);
+
+            console.error(`! The local project doesn't feature a 'packageManager' field - a new one will be created referencing ${installSpec.locator.name}@${installSpec.locator.reference}.`);
+            console.error(`! For more details about this field, consult the documentation at https://nodejs.org/api/corepack.html`);
+            console.error();
+
+            await specUtils.setLocalPackageManager(path.dirname(result.target), installSpec);
+          }
 
           return fallbackDescriptor;
         }

--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -29,20 +29,10 @@ export abstract class BaseCommand extends Command<Context> {
     return resolvedSpecs;
   }
 
-  async setLocalPackageManager(info: PreparedPackageManagerInfo) {
-    const lookup = await specUtils.loadSpec(this.context.cwd);
-
-    const content = lookup.type !== `NoProject`
-      ? await fs.promises.readFile(lookup.target, `utf8`)
-      : ``;
-
-    const {data, indent} = nodeUtils.readPackageJson(content);
-
-    const previousPackageManager = data.packageManager ?? `unknown`;
-    data.packageManager = `${info.locator.name}@${info.locator.reference}+${info.hash}`;
-
-    const newContent = nodeUtils.normalizeLineEndings(content, `${JSON.stringify(data, null, indent)}\n`);
-    await fs.promises.writeFile(lookup.target, newContent, `utf8`);
+  async setAndInstallLocalPackageManager(info: PreparedPackageManagerInfo) {
+    const {
+      previousPackageManager,
+    } = await specUtils.setLocalPackageManager(this.context.cwd, info);
 
     const command = this.context.engine.getPackageManagerSpecFor(info.locator).commands?.use ?? null;
     if (command === null)

--- a/sources/commands/Up.ts
+++ b/sources/commands/Up.ts
@@ -50,6 +50,6 @@ export class UpCommand extends BaseCommand {
     this.context.stdout.write(`Installing ${highestVersion.name}@${highestVersion.reference} in the project...\n`);
 
     const packageManagerInfo = await this.context.engine.ensurePackageManager(highestVersion);
-    await this.setLocalPackageManager(packageManagerInfo);
+    await this.setAndInstallLocalPackageManager(packageManagerInfo);
   }
 }

--- a/sources/commands/Use.ts
+++ b/sources/commands/Use.ts
@@ -34,6 +34,6 @@ export class UseCommand extends BaseCommand {
     this.context.stdout.write(`Installing ${resolved.name}@${resolved.reference} in the project...\n`);
 
     const packageManagerInfo = await this.context.engine.ensurePackageManager(resolved);
-    await this.setLocalPackageManager(packageManagerInfo);
+    await this.setAndInstallLocalPackageManager(packageManagerInfo);
   }
 }

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -40,9 +40,9 @@ export async function fetchAsJson(input: string | URL, init?: RequestInit) {
 
 export async function fetchUrlStream(input: string | URL, init?: RequestInit) {
   if (process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT === `1`) {
-    console.error(`Corepack is about to download ${input}`);
+    console.error(`! Corepack is about to download ${input}`);
     if (stdin.isTTY && !process.env.CI) {
-      stderr.write(`Do you want to continue? [Y/n] `);
+      stderr.write(`? Do you want to continue? [Y/n] `);
       stdin.resume();
       const chars = await once(stdin, `data`);
       stdin.pause();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -311,7 +311,6 @@ for (const name of SupportedPackageManagerSet) {
 
       await expect(runCli(cwd, [name, `--version`])).resolves.toMatchObject({
         stdout: `${config.definitions[name].default.split(`+`, 1)[0]}\n`,
-        stderr: ``,
         exitCode: 0,
       });
     });
@@ -347,7 +346,6 @@ it(`should allow updating the pinned version using the "corepack install -g" com
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       stdout: `1.0.0\n`,
-      stderr: ``,
       exitCode: 0,
     });
   });
@@ -366,7 +364,6 @@ it(`should allow to call "corepack install -g" with a tag`, async () => {
 
     await expect(runCli(cwd, [`npm`, `--version`])).resolves.toMatchObject({
       stdout: expect.stringMatching(/^7\./),
-      stderr: ``,
       exitCode: 0,
     });
   });
@@ -385,7 +382,6 @@ it(`should allow to call "corepack install -g" without any range`, async () => {
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       stdout: expect.not.stringMatching(/^[123]\./),
-      stderr: ``,
       exitCode: 0,
     });
   });
@@ -742,7 +738,7 @@ it(`should show a warning on stderr before downloading when enable`, async() => 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
       stdout: `3.0.0\n`,
-      stderr: `Corepack is about to download https://repo.yarnpkg.com/3.0.0/packages/yarnpkg-cli/bin/yarn.js\n`,
+      stderr: `! Corepack is about to download https://repo.yarnpkg.com/3.0.0/packages/yarnpkg-cli/bin/yarn.js\n`,
     });
   });
 });
@@ -773,7 +769,7 @@ it(`should download yarn classic from custom registry`, async () => {
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
       stdout: /^1\.\d+\.\d+\r?\n$/,
-      stderr: /^Corepack is about to download https:\/\/registry\.npmmirror\.com\/yarn\/-\/yarn-1\.\d+\.\d+\.tgz\r?\n$/,
+      stderr: /^! Corepack is about to download https:\/\/registry\.npmmirror\.com\/yarn\/-\/yarn-1\.\d+\.\d+\.tgz\r?\n$/,
     });
 
     // Should keep working with cache
@@ -797,7 +793,7 @@ it(`should download yarn berry from custom registry`, async () => {
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
       stdout: `3.0.0\n`,
-      stderr: `Corepack is about to download https://registry.npmmirror.com/@yarnpkg/cli-dist/-/cli-dist-3.0.0.tgz\n`,
+      stderr: `! Corepack is about to download https://registry.npmmirror.com/@yarnpkg/cli-dist/-/cli-dist-3.0.0.tgz\n`,
     });
 
     // Should keep working with cache


### PR DESCRIPTION
Once Corepack is enabled, someone restarting their container without having pinned the version of the package manager in `packageManager` may use different package manager versions pre-restart and post-restart, due to Corepack always defaulting on the highest release when the package manager isn't pinned (this was strongly requested in https://github.com/nodejs/corepack/issues/93).

However, we want this "dynamic" selection to be slightly tuned down so it only affects projects as they are created - once a project is created or accessed for the first time, the package manager version should remain the same until the user decides otherwise. People in #399 seemed to agree this was the right behaviour, and I don't have very strong objections on that.

This diff implements this logic by checking whether the command is being run inside an arbitrary folder (`NoProject`), or a project folder whose `package.json` doesn't contain the `packageManager` field (`NoSpec`). In this last case, we write in the `package.json` the spec string for the package manager we'd have selected. No special handling is done to differentiate read commands (`--version`) from write commands (`install`), as I'm not certain this distinction is useful in practice.

Fixes #399; cc @mcollina
