### PR TITLE
chore: remove `fsUtils.rimraf`

### DIFF
--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -11,7 +11,6 @@ import {setTimeout as setTimeoutPromise}                       from 'timers/prom
 import * as engine                                             from './Engine';
 import * as debugUtils                                         from './debugUtils';
 import * as folderUtils                                        from './folderUtils';
-import * as fsUtils                                            from './fsUtils';
 import * as httpUtils                                          from './httpUtils';
 import * as nodeUtils                                          from './nodeUtils';
 import * as npmRegistryUtils                                   from './npmRegistryUtils';
@@ -261,7 +260,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
       ((err as nodeUtils.NodeError).code === `EPERM` && (await fs.promises.stat(installFolder)).isDirectory())
     ) {
       debugUtils.log(`Another instance of corepack installed ${locator.name}@${locator.reference}`);
-      await fsUtils.rimraf(tmpFolder);
+      await fs.promises.rm(tmpFolder, {recursive: true, force: true});
     } else {
       throw err;
     }

--- a/sources/fsUtils.ts
+++ b/sources/fsUtils.ts
@@ -1,5 +1,0 @@
-import {rm} from 'fs/promises';
-
-export async function rimraf(path: string) {
-  return rm(path, {recursive: true, force: true});
-}


### PR DESCRIPTION
The util was useful when we supported Node.js versions without `fs.promises.rm` but after https://github.com/nodejs/corepack/pull/100 we no longer need it and can call `fs.promises.rm` directly, which we're already doing [elsewhere](https://github.com/nodejs/corepack/blob/f442366c1c00d0c3f388b757c3797504f9a6b62e/sources/commands/Cache.ts#L21).