### PR TITLE
fix!: call `executePackageManagerRequest` directly

### DIFF
--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -24,8 +24,8 @@ it(`should refuse to download a package manager if the hash doesn't match`, asyn
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: ``,
-      stdout: /Mismatch hashes/,
+      stderr: /Mismatch hashes/,
+      stdout: ``,
     });
   });
 });
@@ -35,8 +35,8 @@ it(`should refuse to download a known package manager from a URL`, async () => {
     // Package managers known by Corepack cannot be loaded from a URL.
     await expect(runCli(cwd, [`yarn@https://registry.npmjs.com/yarn/-/yarn-1.22.21.tgz`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: ``,
-      stdout: /Illegal use of URL for known package manager/,
+      stderr: /Illegal use of URL for known package manager/,
+      stdout: ``,
     });
 
     // Unknown package managers can be loaded from a URL.
@@ -57,8 +57,8 @@ it.failing(`should refuse to download a known package manager from a URL in pack
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: ``,
-      stdout: /Illegal use of URL for known package manager/,
+      stderr: /Illegal use of URL for known package manager/,
+      stdout: ``,
     });
 
     // Unknown package managers can be loaded from a URL.
@@ -82,8 +82,8 @@ it(`should require a version to be specified`, async () => {
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: ``,
-      stdout: /expected a semver version/,
+      stderr: /expected a semver version/,
+      stdout: ``,
     });
 
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
@@ -92,8 +92,8 @@ it(`should require a version to be specified`, async () => {
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: ``,
-      stdout: /expected a semver version/,
+      stderr: /expected a semver version/,
+      stdout: ``,
     });
 
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
@@ -102,8 +102,8 @@ it(`should require a version to be specified`, async () => {
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: ``,
-      stdout: /expected a semver version/,
+      stderr: /expected a semver version/,
+      stdout: ``,
     });
   });
 });
@@ -272,7 +272,7 @@ it(`shouldn't allow using regular Yarn commands on npm-configured projects`, asy
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: ``,
+      stderr: expect.stringContaining(`This project is configured to use npm`),
     });
   });
 });
@@ -419,9 +419,10 @@ it(`should refuse to run a different package manager within a configured project
     process.env.FORCE_COLOR = `0`;
 
     await expect(runCli(cwd, [`pnpm`, `--version`])).resolves.toMatchObject({
-      stdout: `Usage Error: This project is configured to use yarn because ${
+      stdout: ``,
+      stderr: expect.stringContaining(`This project is configured to use yarn because ${
         npath.fromPortablePath(ppath.join(cwd, `package.json` as Filename))
-      } has a "packageManager" field\n\n$ pnpm ...\n`,
+      } has a "packageManager" field`),
       exitCode: 1,
     });
 
@@ -471,8 +472,8 @@ it(`should support disabling the network accesses from the environment`, async (
     });
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
-      stdout: expect.stringContaining(`Network access disabled by the environment`),
-      stderr: ``,
+      stdout: ``,
+      stderr: expect.stringContaining(`Network access disabled by the environment`),
       exitCode: 1,
     });
   });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -999,13 +999,13 @@ describe(`handle integrity checks`, () => {
     await xfs.mktempPromise(async cwd => {
       await expect(runCli(cwd, [`pnpm@1.x`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Signature does not match/,
-        stderr: ``,
+        stderr: /Signature does not match/,
+        stdout: ``,
       });
       await expect(runCli(cwd, [`yarn@stable`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Signature does not match/,
-        stderr: ``,
+        stderr: /Signature does not match/,
+        stdout: ``,
       });
     });
   });
@@ -1015,19 +1015,19 @@ describe(`handle integrity checks`, () => {
     await xfs.mktempPromise(async cwd => {
       await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Mismatch hashes. Expected [a-f0-9]{128}, got [a-f0-9]{128}/,
-        stderr: ``,
+        stderr: /Mismatch hashes. Expected [a-f0-9]{128}, got [a-f0-9]{128}/,
+        stdout: ``,
       });
       // A second time to validate the invalid version was not cached.
       await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Mismatch hashes. Expected [a-f0-9]{128}, got [a-f0-9]{128}/,
-        stderr: ``,
+        stderr: /Mismatch hashes. Expected [a-f0-9]{128}, got [a-f0-9]{128}/,
+        stdout: ``,
       });
       await expect(runCli(cwd, [`yarn`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Mismatch hashes. Expected [a-f0-9]{128}, got [a-f0-9]{128}/,
-        stderr: ``,
+        stderr: /Mismatch hashes. Expected [a-f0-9]{128}, got [a-f0-9]{128}/,
+        stdout: ``,
       });
       await expect(runCli(cwd, [`use`, `pnpm`], true)).resolves.toMatchObject({
         exitCode: 1,
@@ -1042,19 +1042,19 @@ describe(`handle integrity checks`, () => {
     await xfs.mktempPromise(async cwd => {
       await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Signature does not match/,
-        stderr: ``,
+        stderr: /Signature does not match/,
+        stdout: ``,
       });
       // A second time to validate the invalid version was not cached.
       await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Signature does not match/,
-        stderr: ``,
+        stderr: /Signature does not match/,
+        stdout: ``,
       });
       await expect(runCli(cwd, [`yarn`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Signature does not match/,
-        stderr: ``,
+        stderr: /Signature does not match/,
+        stdout: ``,
       });
       await expect(runCli(cwd, [`use`, `pnpm`], true)).resolves.toMatchObject({
         exitCode: 1,
@@ -1069,8 +1069,8 @@ describe(`handle integrity checks`, () => {
     await xfs.mktempPromise(async cwd => {
       await expect(runCli(cwd, [`yarn@1.9998.9999`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Signature does not match/,
-        stderr: ``,
+        stderr: /Signature does not match/,
+        stdout: ``,
       });
       await expect(runCli(cwd, [`use`, `yarn@1.9998.9999`], true)).resolves.toMatchObject({
         exitCode: 1,
@@ -1085,8 +1085,8 @@ describe(`handle integrity checks`, () => {
     await xfs.mktempPromise(async cwd => {
       await expect(runCli(cwd, [`yarn@1.9998.9999`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stdout: /Mismatch hashes. Expected [a-f0-9]{128}, got [a-f0-9]{128}/,
-        stderr: ``,
+        stderr: /Mismatch hashes. Expected [a-f0-9]{128}, got [a-f0-9]{128}/,
+        stdout: ``,
       });
       await expect(runCli(cwd, [`use`, `yarn@1.9998.9999`], true)).resolves.toMatchObject({
         exitCode: 1,
@@ -1102,10 +1102,10 @@ describe(`handle integrity checks`, () => {
       const result = await runCli(cwd, [`yarn@1.9998.9999+sha1.deadbeef`, `--version`], true);
       expect(result).toMatchObject({
         exitCode: 1,
-        stderr: ``,
+        stdout: ``,
       });
-      const match = /Mismatch hashes. Expected deadbeef, got ([a-f0-9]{40})/.exec(result.stdout);
-      if (match == null) throw new Error(`Invalid output`, {cause: result.stdout});
+      const match = /Mismatch hashes. Expected deadbeef, got ([a-f0-9]{40})/.exec(result.stderr);
+      if (match == null) throw new Error(`Invalid output`, {cause: result.stderr});
       await expect(runCli(cwd, [`yarn@1.9998.9999+sha1.${match[1]}`, `--version`], true)).resolves.toMatchObject({
         exitCode: 0,
         stdout: `yarn: Hello from custom registry\n`,

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -272,7 +272,7 @@ it(`shouldn't allow using regular Yarn commands on npm-configured projects`, asy
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: expect.stringContaining(`This project is configured to use npm`),
+      stderr: /This project is configured to use npm/,
     });
   });
 });
@@ -473,7 +473,7 @@ it(`should support disabling the network accesses from the environment`, async (
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       stdout: ``,
-      stderr: expect.stringContaining(`Network access disabled by the environment`),
+      stderr: /Network access disabled by the environment/,
       exitCode: 1,
     });
   });


### PR DESCRIPTION
Calling `executePackageManagerRequest` directly instead of through Clipanion lets Node.js handle printing errors which results in the `cause` property being printed correctly.

Ref https://github.com/nodejs/corepack/issues/458 and others like it.
Ref https://github.com/nodejs/corepack/pull/425#issuecomment-2000189938

Depends on
- https://github.com/nodejs/corepack/pull/428

Performance is roughly the same
```console
$ hyperfine -w 5 "node ./dist-before/yarn.js -v" "node ./dist-after/yarn.js -v"
Benchmark 1: node ./dist-before/yarn.js -v
  Time (mean ± σ):     188.0 ms ±   9.9 ms    [User: 204.5 ms, System: 22.3 ms]
  Range (min … max):   179.0 ms … 222.1 ms    16 runs

Benchmark 2: node ./dist-after/yarn.js -v
  Time (mean ± σ):     186.5 ms ±   7.8 ms    [User: 202.5 ms, System: 22.4 ms]
  Range (min … max):   178.1 ms … 204.9 ms    16 runs

Summary
  node ./dist-after/yarn.js -v ran
    1.01 ± 0.07 times faster than node ./dist-before/yarn.js -v
```

BREAKING CHANGE:
Some errors are now printed to stderr instead of stdout