### PR TITLE
Follow custom registry redirect

### DIFF
--- a/sources/npmRegistryUtils.ts
+++ b/sources/npmRegistryUtils.ts
@@ -25,7 +25,10 @@ export async function fetchAsJson(packageName: string) {
     headers.authorization = `Basic ${encodedCreds}`;
   }
 
-  return httpUtils.fetchAsJson(`${npmRegistryUrl}/${packageName}`, {headers});
+  return httpUtils.fetchAsJson(`${npmRegistryUrl}/${packageName}`, {
+    headers,
+    redirect: 'follow',
+  });
 }
 
 export async function fetchLatestStableVersion(packageName: string) {


### PR DESCRIPTION
## Problem
### Custom registry:
`export COREPACK_NPM_REGISTRY="https://npm.mycompany.com"`

### Request:
```
> GET /npm HTTP/1.1
> Host: npm.mycompany.ru
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/1.1 302 Found
< Access-Control-Allow-Origin: *
< Cache-Control: no-cache
< Content-Length: 5
< Content-Type: text/plain; charset=utf-8
< Date: Wed, 20 Mar 2024 11:41:45 GMT
< Location: https://verdaccio.s3.mycompany.net/npm/package.json
```

### Corepack fails:
```
[2024-03-20 04:04:33] Internal Error: Server answered with HTTP 302
[2024-03-20 04:04:33]     at ClientRequest.<anonymous> (/node-v18.14.2-linux-x64/lib/node_modules/corepack/dist/corepack.js:16069:31)
[2024-03-20 04:04:33]     at Object.onceWrapper (node:events:628:26)
[2024-03-20 04:04:33]     at ClientRequest.emit (node:events:513:28)
[2024-03-20 04:04:33]     at HTTPParser.parserOnIncomingClient [as onIncoming] (node:_http_client:701:27)
[2024-03-20 04:04:33]     at HTTPParser.parserOnHeadersComplete (node:_http_common:119:17)
[2024-03-20 04:04:33]     at TLSSocket.socketOnData (node:_http_client:542:22)
[2024-03-20 04:04:33]     at TLSSocket.emit (node:events:513:28)
[2024-03-20 04:04:33]     at addChunk (node:internal/streams/readable:324:12)
[2024-03-20 04:04:33]     at readableAddChunk (node:internal/streams/readable:297:9)
[2024-03-20 04:04:33]     at Readable.push (node:internal/streams/readable:234:10)
```

## Solution:
Enable fetch option to follow redirect
https://developer.mozilla.org/ru/docs/Web/API/Fetch_API/Using_Fetch