### PR TITLE
feat: download only `yarn.js` from npm

### DIFF
--- a/config.json
+++ b/config.json
@@ -149,7 +149,8 @@
           },
           "npmRegistry": {
             "type": "npm",
-            "package": "@yarnpkg/cli-dist"
+            "package": "@yarnpkg/cli-dist",
+            "bin": "bin/yarn.js"
           },
           "commands": {
             "use": [

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -155,10 +155,7 @@ async function download(installTarget: string, url: string, algo: string, binPat
       cwd: tmpFolder,
       filter: binPath ? path => {
         const pos = path.indexOf(`/`);
-        if (pos === -1 || path.slice(pos + 1) !== binPath)
-          return false;
-
-        return true;
+        return pos !== -1 && path.slice(pos + 1) === binPath;
       } : undefined,
     });
   } else if (ext === `.js`) {

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -161,12 +161,9 @@ async function download(installTarget: string, url: string, algo: string, binPat
   await once(sendTo, `finish`);
 
   if (binPath) {
-    await once(sendTo, `finish`);
-
     const downloadedBin = path.join(downloadFolder, binPath);
     if (!fs.existsSync(downloadedBin))
       throw new Error(`Cannot locate '${binPath}' in downloaded tarball`);
-
 
     // Create a new folder which only contains the bin file
     const tmpFolder = folderUtils.getTemporaryFolder(installTarget);
@@ -181,7 +178,7 @@ async function download(installTarget: string, url: string, algo: string, binPat
     // Calculate the hash of the bin file
     const fileStream = fs.createReadStream(outputFile);
     const fileHash = fileStream.pipe(createHash(algo));
-    await once(fileStream, `finish`);
+    await once(fileStream, `close`);
 
     return {
       tmpFolder,

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -191,7 +191,7 @@ async function download(installTarget: string, url: string, algo: string, binPat
   return {
     tmpFolder,
     outputFile,
-    hash: hash.digest(`hex`),
+    hash: hash!.digest(`hex`),
   };
 }
 

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -167,10 +167,9 @@ async function download(installTarget: string, url: string, algo: string, binPat
   }
   stream.pipe(sendTo);
 
-  const streamHash = !binPath ? stream.pipe(createHash(algo)) : null;
+  let hash = !binPath ? stream.pipe(createHash(algo)) : null;
   await once(sendTo, `finish`);
 
-  let hash: string;
   if (binPath) {
     const downloadedBin = path.join(tmpFolder, binPath);
     outputFile = path.join(tmpFolder, path.basename(downloadedBin));
@@ -185,18 +184,14 @@ async function download(installTarget: string, url: string, algo: string, binPat
 
     // Calculate the hash of the bin file
     const fileStream = fs.createReadStream(outputFile);
-    const fileHash = fileStream.pipe(createHash(algo));
+    hash = fileStream.pipe(createHash(algo));
     await once(fileStream, `close`);
-
-    hash = fileHash.digest(`hex`);
-  } else {
-    hash = streamHash.digest(`hex`);
   }
 
   return {
     tmpFolder,
     outputFile,
-    hash,
+    hash: hash.digest(`hex`),
   };
 }
 

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -170,6 +170,7 @@ async function download(installTarget: string, url: string, algo: string, binPat
   const streamHash = stream.pipe(createHash(algo));
   await once(sendTo, `finish`);
 
+  let hash: string;
   if (binPath) {
     const downloadedBin = path.join(tmpFolder, binPath);
     outputFile = path.join(tmpFolder, path.basename(downloadedBin));
@@ -187,17 +188,15 @@ async function download(installTarget: string, url: string, algo: string, binPat
     const fileHash = fileStream.pipe(createHash(algo));
     await once(fileStream, `close`);
 
-    return {
-      tmpFolder,
-      outputFile,
-      hash: fileHash.digest(`hex`),
-    };
+    hash = fileHash.digest(`hex`);
+  } else {
+    hash = streamHash.digest(`hex`);
   }
 
   return {
     tmpFolder,
     outputFile,
-    hash: streamHash.digest(`hex`),
+    hash,
   };
 }
 

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -1,21 +1,21 @@
-import {createHash}                                                          from 'crypto';
-import {once}                                                                from 'events';
-import {FileHandle}                                                          from 'fs/promises';
-import fs                                                                    from 'fs';
-import type {Dir}                                                            from 'fs';
-import Module                                                                from 'module';
-import path                                                                  from 'path';
-import semver                                                                from 'semver';
-import {setTimeout as setTimeoutPromise}                                     from 'timers/promises';
+import {createHash}                                            from 'crypto';
+import {once}                                                  from 'events';
+import {FileHandle}                                            from 'fs/promises';
+import fs                                                      from 'fs';
+import type {Dir}                                              from 'fs';
+import Module                                                  from 'module';
+import path                                                    from 'path';
+import semver                                                  from 'semver';
+import {setTimeout as setTimeoutPromise}                       from 'timers/promises';
 
-import * as engine                                                           from './Engine';
-import * as debugUtils                                                       from './debugUtils';
-import * as folderUtils                                                      from './folderUtils';
-import * as httpUtils                                                        from './httpUtils';
-import * as nodeUtils                                                        from './nodeUtils';
-import * as npmRegistryUtils                                                 from './npmRegistryUtils';
+import * as engine                                             from './Engine';
+import * as debugUtils                                         from './debugUtils';
+import * as folderUtils                                        from './folderUtils';
+import * as httpUtils                                          from './httpUtils';
+import * as nodeUtils                                          from './nodeUtils';
+import * as npmRegistryUtils                                   from './npmRegistryUtils';
 import {RegistrySpec, Descriptor, Locator, PackageManagerSpec} from './types';
-import {BinList, BinSpec, InstallSpec, DownloadSpec}                                       from './types';
+import {BinList, BinSpec, InstallSpec, DownloadSpec}           from './types';
 
 export function getRegistryFromPackageManagerSpec(spec: PackageManagerSpec) {
   return process.env.COREPACK_NPM_REGISTRY
@@ -176,9 +176,9 @@ async function download(installTarget: string, url: string, algo: string, binPat
     try {
       await renameSafe(downloadedBin, outputFile);
     } catch (err) {
-      if ((err as nodeUtils.NodeError)?.code === `ENOENT`) {
-        throw new Error(`Cannot locate '${binPath}' in downloaded tarball`, { cause: err });
-      }
+      if ((err as nodeUtils.NodeError)?.code === `ENOENT`)
+        throw new Error(`Cannot locate '${binPath}' in downloaded tarball`, {cause: err});
+
       throw err;
     }
 

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -167,7 +167,7 @@ async function download(installTarget: string, url: string, algo: string, binPat
   }
   stream.pipe(sendTo);
 
-  const streamHash = stream.pipe(createHash(algo));
+  const streamHash = !binPath ? stream.pipe(createHash(algo)) : null;
   await once(sendTo, `finish`);
 
   let hash: string;

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -14,8 +14,8 @@ import * as folderUtils                                                      fro
 import * as httpUtils                                                        from './httpUtils';
 import * as nodeUtils                                                        from './nodeUtils';
 import * as npmRegistryUtils                                                 from './npmRegistryUtils';
-import {RegistrySpec, Descriptor, Locator, PackageManagerSpec, DownloadSpec} from './types';
-import {BinList, BinSpec, InstallSpec}                                       from './types';
+import {RegistrySpec, Descriptor, Locator, PackageManagerSpec} from './types';
+import {BinList, BinSpec, InstallSpec, DownloadSpec}                                       from './types';
 
 export function getRegistryFromPackageManagerSpec(spec: PackageManagerSpec) {
   return process.env.COREPACK_NPM_REGISTRY

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -174,7 +174,7 @@ async function download(installTarget: string, url: string, algo: string, binPat
     const downloadedBin = path.join(tmpFolder, binPath);
     outputFile = path.join(tmpFolder, path.basename(downloadedBin));
     try {
-      await rename(downloadedBin, outputFile);
+      await renameSafe(downloadedBin, outputFile);
     } catch (err) {
       if ((err as nodeUtils.NodeError)?.code === `ENOENT`) {
         throw new Error(`Cannot locate '${binPath}' in downloaded tarball`, { cause: err });
@@ -347,7 +347,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
   };
 }
 
-async function rename(oldPath: fs.PathLike, newPath: fs.PathLike) {
+async function renameSafe(oldPath: fs.PathLike, newPath: fs.PathLike) {
   if (process.platform === `win32`) {
     await renameUnderWindows(oldPath, newPath);
   } else {

--- a/sources/types.ts
+++ b/sources/types.ts
@@ -25,6 +25,7 @@ export function isSupportedPackageManager(value: string): value is SupportedPack
 export interface NpmRegistrySpec {
   type: `npm`;
   package: string;
+  bin?: string;
 }
 
 export interface UrlRegistrySpec {
@@ -56,6 +57,12 @@ export interface PackageManagerSpec {
 export interface InstallSpec {
   location: string;
   bin?: BinList | BinSpec;
+  hash: string;
+}
+
+export interface DownloadSpec {
+  tmpFolder: string;
+  outputFile: string | null;
   hash: string;
 }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -787,7 +787,7 @@ it(`should download yarn berry from custom registry`, async () => {
     process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT = `1`;
 
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
-      packageManager: `yarn@4.1.1+sha256.f3cc0eda8e5560e529c7147565b30faa43b4e472d90e8634d7134a37c7f59781`,
+      packageManager: `yarn@3.0.0-rc.2+sha224.f83f6d1cbfac10ba6b516a62ccd2a72ccd857aa6c514d1cd7185ec60`,
     });
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -792,14 +792,14 @@ it(`should download yarn berry from custom registry`, async () => {
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
-      stdout: `4.1.1\n`,
-      stderr: `! Corepack is about to download https://registry.npmmirror.com/@yarnpkg/cli-dist/-/cli-dist-4.1.1.tgz\n`,
+      stdout: `3.0.0-rc.2\n`,
+      stderr: `! Corepack is about to download https://registry.npmmirror.com/@yarnpkg/cli-dist/-/cli-dist-3.0.0-rc.2.tgz\n`,
     });
 
     // Should keep working with cache
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
-      stdout: `4.1.1\n`,
+      stdout: `3.0.0-rc.2\n`,
       stderr: ``,
     });
   });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -787,19 +787,19 @@ it(`should download yarn berry from custom registry`, async () => {
     process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT = `1`;
 
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
-      packageManager: `yarn@3.0.0`,
+      packageManager: `yarn@4.1.1+sha256.f3cc0eda8e5560e529c7147565b30faa43b4e472d90e8634d7134a37c7f59781`,
     });
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
-      stdout: `3.0.0\n`,
-      stderr: `! Corepack is about to download https://registry.npmmirror.com/@yarnpkg/cli-dist/-/cli-dist-3.0.0.tgz\n`,
+      stdout: `4.1.1\n`,
+      stderr: `! Corepack is about to download https://registry.npmmirror.com/@yarnpkg/cli-dist/-/cli-dist-4.1.1.tgz\n`,
     });
 
     // Should keep working with cache
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
-      stdout: `3.0.0\n`,
+      stdout: `4.1.1\n`,
       stderr: ``,
     });
   });


### PR DESCRIPTION
Added `bin` property to `NpmRegistrySpec`. When installing yarn berry from custom registry, it'll only install the bin file and calculate hash of the bin file itself.

Fix #435 