### PR TITLE
fix: Incorrect authorization prefix for basic auth, and undocumented env var

### DIFF
--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -29,12 +29,7 @@ async function fetch(input: string | URL, init?: RequestInit) {
     input.username = input.password = ``;
   }
 
-  const registries = [
-    process.env.COREPACK_NPM_REGISTRY,
-    DEFAULT_NPM_REGISTRY_URL,
-  ].filter(Boolean);
-
-  if (registries.includes(input.origin) && process.env.COREPACK_NPM_TOKEN) {
+  if (input.origin === (process.env.COREPACK_NPM_REGISTRY || DEFAULT_NPM_REGISTRY_URL) && process.env.COREPACK_NPM_TOKEN) {
     headers =  {
       ...headers,
       authorization: `Bearer ${process.env.COREPACK_NPM_TOKEN}`,

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -16,27 +16,27 @@ async function fetch(input: string | URL, init?: RequestInit) {
     input = new URL(input);
 
   let headers = init?.headers;
-  const {username, password} = input;
+
+  const username: string | undefined = input.username ?? process.env.COREPACK_NPM_USERNAME;
+  const password: string | undefined = input.password ?? process.env.COREPACK_NPM_PASSWORD;
+
   if (username || password) {
     headers =  {
       ...headers,
       authorization: `Basic ${Buffer.from(`${username}:${password}`).toString(`base64`)}`,
     };
+
     input.username = input.password = ``;
-  } else if (input.origin === process.env.COREPACK_NPM_REGISTRY || DEFAULT_NPM_REGISTRY_URL) {
+  }
+
+  if (input.origin === process.env.COREPACK_NPM_REGISTRY || DEFAULT_NPM_REGISTRY_URL) {
     if (process.env.COREPACK_NPM_TOKEN) {
       headers =  {
         ...headers,
         authorization: `Bearer ${process.env.COREPACK_NPM_TOKEN}`,
       };
-    } else if (`COREPACK_NPM_PASSWORD` in process.env) {
-      headers =  {
-        ...headers,
-        authorization: `Basic ${Buffer.from(`${process.env.COREPACK_NPM_USERNAME}:${process.env.COREPACK_NPM_PASSWORD}`).toString(`base64`)}`,
-      };
     }
   }
-
 
   let response;
   try {

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -29,13 +29,16 @@ async function fetch(input: string | URL, init?: RequestInit) {
     input.username = input.password = ``;
   }
 
-  if (input.origin === process.env.COREPACK_NPM_REGISTRY || DEFAULT_NPM_REGISTRY_URL) {
-    if (process.env.COREPACK_NPM_TOKEN) {
-      headers =  {
-        ...headers,
-        authorization: `Bearer ${process.env.COREPACK_NPM_TOKEN}`,
-      };
-    }
+  const registries = [
+    process.env.COREPACK_NPM_REGISTRY,
+    DEFAULT_NPM_REGISTRY_URL,
+  ].filter(Boolean);
+
+  if (registries.includes(input.origin) && process.env.COREPACK_NPM_TOKEN) {
+    headers =  {
+      ...headers,
+      authorization: `Bearer ${process.env.COREPACK_NPM_TOKEN}`,
+    };
   }
 
   let response;

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -32,7 +32,7 @@ async function fetch(input: string | URL, init?: RequestInit) {
     } else if (`COREPACK_NPM_PASSWORD` in process.env) {
       headers =  {
         ...headers,
-        authorization: `Basic ${Buffer.from(`${process.env.COREPACK_NPM_USER}:${process.env.COREPACK_NPM_PASSWORD}`).toString(`base64`)}`,
+        authorization: `Basic ${Buffer.from(`${process.env.COREPACK_NPM_USERNAME}:${process.env.COREPACK_NPM_PASSWORD}`).toString(`base64`)}`,
       };
     }
   }

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -20,7 +20,7 @@ async function fetch(input: string | URL, init?: RequestInit) {
   if (username || password) {
     headers =  {
       ...headers,
-      authorization: `Bearer ${Buffer.from(`${username}:${password}`).toString(`base64`)}`,
+      authorization: `Basic ${Buffer.from(`${username}:${password}`).toString(`base64`)}`,
     };
     input.username = input.password = ``;
   } else if (input.origin === process.env.COREPACK_NPM_REGISTRY || DEFAULT_NPM_REGISTRY_URL) {
@@ -32,7 +32,7 @@ async function fetch(input: string | URL, init?: RequestInit) {
     } else if (`COREPACK_NPM_PASSWORD` in process.env) {
       headers =  {
         ...headers,
-        authorization: `Bearer ${Buffer.from(`${process.env.COREPACK_NPM_USER}:${process.env.COREPACK_NPM_PASSWORD}`).toString(`base64`)}`,
+        authorization: `Basic ${Buffer.from(`${process.env.COREPACK_NPM_USER}:${process.env.COREPACK_NPM_PASSWORD}`).toString(`base64`)}`,
       };
     }
   }

--- a/tests/_registryServer.mjs
+++ b/tests/_registryServer.mjs
@@ -66,7 +66,8 @@ function generateVersionMetadata(packageName, version) {
 
 const server = createServer((req, res) => {
   const auth = req.headers.authorization;
-  if (!auth?.startsWith(`Basic `) || Buffer.from(auth.slice(`Basic `.length), `base64`).toString() !== `user:pass`) {
+
+  if (auth?.startsWith(`Basic `) && Buffer.from(auth.slice(`Basic `.length), `base64`).toString() !== `user:pass`) {
     res.writeHead(401).end(`Unauthorized`);
     return;
   }
@@ -127,7 +128,7 @@ switch (process.env.AUTH_TYPE) {
 
   case `COREPACK_NPM_PASSWORD`:
     process.env.COREPACK_NPM_REGISTRY = `http://${address.includes(`:`) ? `[${address}]` : address}:${port}`;
-    process.env.COREPACK_NPM_USER = `user`;
+    process.env.COREPACK_NPM_USERNAME = `user`;
     process.env.COREPACK_NPM_PASSWORD = `pass`;
     break;
 

--- a/tests/_registryServer.mjs
+++ b/tests/_registryServer.mjs
@@ -66,7 +66,7 @@ function generateVersionMetadata(packageName, version) {
 
 const server = createServer((req, res) => {
   const auth = req.headers.authorization;
-  if (!auth?.startsWith(`Bearer `) || Buffer.from(auth.slice(`Bearer `.length), `base64`).toString() !== `user:pass`) {
+  if (!auth?.startsWith(`Basic `) || Buffer.from(auth.slice(`Basic `.length), `base64`).toString() !== `user:pass`) {
     res.writeHead(401).end(`Unauthorized`);
     return;
   }


### PR DESCRIPTION
Changes auth type header strings to use `Basic` prefix for base64 encoded username:password.

In addition, it seems like an undocumented env var `COREPACK_NPM_USER` is being used in tests, meaning that this value will be `undefined` and the user will always get a 401 as the documented env var is `COREPACK_NPM_USERNAME`.
This bit me when I was using a test to help debug why my COREPACK_NPM_REGISTRY was being ignored when running `yarn --version` in real life.