### PR TITLE
fix: add path to `package.json` in error message

### DIFF
--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -278,7 +278,7 @@ export class Engine {
             if (transparent) {
               return fallbackDescriptor;
             } else {
-              throw new UsageError(`This project is configured to use ${result.spec.name}`);
+              throw new UsageError(`This project is configured to use ${result.spec.name} because ${result.target} defines a "packageManager" field`);
             }
           } else {
             return result.spec;

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -278,7 +278,7 @@ export class Engine {
             if (transparent) {
               return fallbackDescriptor;
             } else {
-              throw new UsageError(`This project is configured to use ${result.spec.name} because ${result.target} defines a "packageManager" field`);
+              throw new UsageError(`This project is configured to use ${result.spec.name} because ${result.target} has a "packageManager" field`);
             }
           } else {
             return result.spec;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -421,7 +421,7 @@ it(`should refuse to run a different package manager within a configured project
     await expect(runCli(cwd, [`pnpm`, `--version`])).resolves.toMatchObject({
       stdout: `Usage Error: This project is configured to use yarn because ${
         ppath.join(cwd, `package.json` as Filename)
-      } defines a "packageManager" field\n\n$ pnpm ...\n`,
+      } has a "packageManager" field\n\n$ pnpm ...\n`,
       exitCode: 1,
     });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,6 +1,7 @@
 import {beforeEach, describe, expect, it}          from '@jest/globals';
 import {Filename, ppath, xfs, npath, PortablePath} from '@yarnpkg/fslib';
 import os                                          from 'node:os';
+import path                                        from 'node:path';
 import process                                     from 'node:process';
 
 import config                                      from '../config.json';
@@ -420,7 +421,8 @@ it(`should refuse to run a different package manager within a configured project
 
     await expect(runCli(cwd, [`pnpm`, `--version`])).resolves.toMatchObject({
       stdout: `Usage Error: This project is configured to use yarn because ${
-        ppath.join(cwd, `package.json` as Filename)
+        // ppath and xfs do not format Windows correctly, the regex fixes that:
+        path.join(cwd.replace(/^\/([a-zA-Z]:)\//, `$1\\`), `package.json`)
       } has a "packageManager" field\n\n$ pnpm ...\n`,
       exitCode: 1,
     });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -419,7 +419,9 @@ it(`should refuse to run a different package manager within a configured project
     process.env.FORCE_COLOR = `0`;
 
     await expect(runCli(cwd, [`pnpm`, `--version`])).resolves.toMatchObject({
-      stdout: `Usage Error: This project is configured to use yarn\n\n$ pnpm ...\n`,
+      stdout: `Usage Error: This project is configured to use yarn because ${
+        ppath.join(cwd, `package.json` as Filename)
+      } defines a "packageManager" field\n\n$ pnpm ...\n`,
       exitCode: 1,
     });
 


### PR DESCRIPTION
I had to help someone who couldn't understand why they were getting this error message on an empty directory; turned out they had a `package.json` in their home directory (no idea how it got there) that defined a `packageManager` field. I think adding some explanation would help.