### PR TITLE
fix: COREPACK_NPM_REGISTRY should allow for username/password auth

### DIFF
--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -17,8 +17,8 @@ async function fetch(input: string | URL, init?: RequestInit) {
 
   let headers = init?.headers;
 
-  const username: string | undefined = input.username ?? process.env.COREPACK_NPM_USERNAME;
-  const password: string | undefined = input.password ?? process.env.COREPACK_NPM_PASSWORD;
+  const username: string | undefined = input.username || process.env.COREPACK_NPM_USERNAME;
+  const password: string | undefined = input.password || process.env.COREPACK_NPM_PASSWORD;
 
   if (username || password) {
     headers =  {

--- a/tests/_registryServer.mjs
+++ b/tests/_registryServer.mjs
@@ -116,8 +116,10 @@ const server = createServer((req, res) => {
   const auth = req.headers.authorization;
 
   if (
-    (auth?.startsWith(`Bearer `) && auth.slice(`Bearer `.length) !== TOKEN_MOCK) ||
-    (auth?.startsWith(`Basic `) && Buffer.from(auth.slice(`Basic `.length), `base64`).toString() !== `user:pass`)
+    auth == null ||
+    (auth.startsWith(`Bearer `) && auth.slice(`Bearer `.length) !== TOKEN_MOCK) ||
+    (auth.startsWith(`Basic `) && Buffer.from(auth.slice(`Basic `.length), `base64`).toString() !== `user:pass`) ||
+    !/^(Basic|Bearer) /.test(auth)
   ) {
     res.writeHead(401).end(`Unauthorized`);
     return;


### PR DESCRIPTION
I noticed when using this package, if you set `COREPACK_NPM_REGISTRY`, authentication wasn't working as expected.

After debugging and reading through the code, it appears that when the following code was run:
```
if (typeof input === `string`)
    input = new URL(input);
```
`input.username` would become an empty string. This caused `process.env.COREPACK_NPM_USERNAME` to not be used. 

By switching `??` to `||`, the authorization header should now be sent to the registry as expected!