### PR TITLE
feat: COREPACK_INTEGRITY_KEYS should support `0` and `false` values

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,9 @@ same major line. Should you need to upgrade to a new major, use an explicit
 - `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` are supported through
   [`node-proxy-agent`](https://github.com/TooTallNate/node-proxy-agent).
 
-- `COREPACK_INTEGRITY_KEYS` can be set to an empty string to instruct Corepack
-  to skip integrity checks, or a JSON string containing custom keys.
+- `COREPACK_INTEGRITY_KEYS` can be set to an empty string, `0`, or `false` to
+  instruct Corepack to skip integrity checks, or to a JSON string containing
+  custom keys.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ same major line. Should you need to upgrade to a new major, use an explicit
 - `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` are supported through
   [`node-proxy-agent`](https://github.com/TooTallNate/node-proxy-agent).
 
-- `COREPACK_INTEGRITY_KEYS` can be set to an empty string, `0`, or `false` to
+- `COREPACK_INTEGRITY_KEYS` can be set to an empty string or `0` to
   instruct Corepack to skip integrity checks, or to a JSON string containing
   custom keys.
 

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -434,7 +434,6 @@ export async function runVersion(locator: Locator, installSpec: InstallSpec & {s
 }
 
 export function shouldSkipIntegrityCheck() {
-  return [``, `0`].includes(
-    process.env.COREPACK_INTEGRITY_KEYS?.toLowerCase().trim(),
-  );
+  return process.env.COREPACK_INTEGRITY_KEYS === ``
+    || process.env.COREPACK_INTEGRITY_KEYS === `0`;
 }

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -434,7 +434,7 @@ export async function runVersion(locator: Locator, installSpec: InstallSpec & {s
 }
 
 export function shouldSkipIntegrityCheck() {
-  return [``, `0`, `false`].includes(
-    process.env.COREPACK_INTEGRITY_KEYS?.toLowerCase().trim()
+  return [``, `0`].includes(
+    process.env.COREPACK_INTEGRITY_KEYS?.toLowerCase().trim(),
   );
 }

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -283,7 +283,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
 
   if (!build[1]) {
     const registry = getRegistryFromPackageManagerSpec(spec);
-    if (registry.type === `npm` && !registry.bin && process.env.COREPACK_INTEGRITY_KEYS !== ``) {
+    if (registry.type === `npm` && !registry.bin && !shouldSkipIntegrityCheck()) {
       if (signatures! == null || integrity! == null)
         ({signatures, integrity} = (await npmRegistryUtils.fetchTarballURLAndSignature(registry.package, version)));
 
@@ -431,4 +431,10 @@ export async function runVersion(locator: Locator, installSpec: InstallSpec & {s
   // Use nextTick to unwind the stack, and consequently remove Corepack from
   // the stack trace of the package manager.
   process.nextTick(Module.runMain, binPath);
+}
+
+export function shouldSkipIntegrityCheck() {
+  return [``, `0`, `false`].includes(
+    process.env.COREPACK_INTEGRITY_KEYS?.toLowerCase().trim()
+  );
 }

--- a/sources/npmRegistryUtils.ts
+++ b/sources/npmRegistryUtils.ts
@@ -1,10 +1,10 @@
-import {UsageError}   from 'clipanion';
-import {createVerify} from 'crypto';
+import {UsageError}               from 'clipanion';
+import {createVerify}             from 'crypto';
 
-import defaultConfig  from '../config.json';
+import defaultConfig              from '../config.json';
 
-import * as httpUtils from './httpUtils';
-import { shouldSkipIntegrityCheck } from './corepackUtils';
+import {shouldSkipIntegrityCheck} from './corepackUtils';
+import * as httpUtils             from './httpUtils';
 
 // load abbreviated metadata as that's all we need for these calls
 // see: https://github.com/npm/registry/blob/cfe04736f34db9274a780184d1cdb2fb3e4ead2a/docs/responses/package-metadata.md

--- a/sources/npmRegistryUtils.ts
+++ b/sources/npmRegistryUtils.ts
@@ -4,6 +4,7 @@ import {createVerify} from 'crypto';
 import defaultConfig  from '../config.json';
 
 import * as httpUtils from './httpUtils';
+import { shouldSkipIntegrityCheck } from './corepackUtils';
 
 // load abbreviated metadata as that's all we need for these calls
 // see: https://github.com/npm/registry/blob/cfe04736f34db9274a780184d1cdb2fb3e4ead2a/docs/responses/package-metadata.md
@@ -63,7 +64,7 @@ export async function fetchLatestStableVersion(packageName: string) {
 
   const {version, dist: {integrity, signatures}} = metadata;
 
-  if (process.env.COREPACK_INTEGRITY_KEYS !== ``) {
+  if (!shouldSkipIntegrityCheck()) {
     verifySignature({
       packageName, version,
       integrity, signatures,

--- a/tests/corepackUtils.test.ts
+++ b/tests/corepackUtils.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "@jest/globals";
+import {describe, it, expect}     from '@jest/globals';
 
-import { shouldSkipIntegrityCheck } from "../sources/corepackUtils";
+import {shouldSkipIntegrityCheck} from '../sources/corepackUtils';
 
 describe(`corepack utils shouldSkipIntegrityCheck`, () => {
   it(`should return false if COREPACK_INTEGRITY_KEYS env is not set`, () => {
@@ -13,28 +13,18 @@ describe(`corepack utils shouldSkipIntegrityCheck`, () => {
     expect(shouldSkipIntegrityCheck()).toBe(true);
   });
 
-  it(`should return true if COREPACK_INTEGRITY_KEYS env is set to false`, () => {
-    process.env.COREPACK_INTEGRITY_KEYS = `false`;
-    expect(shouldSkipIntegrityCheck()).toBe(true);
-  });
-
-  it(`should return true if COREPACK_INTEGRITY_KEYS env is set to FALSE`, () => {
-    process.env.COREPACK_INTEGRITY_KEYS = `FALSE`;
-    expect(shouldSkipIntegrityCheck()).toBe(true);
-  });
-
   it(`should return true if COREPACK_INTEGRITY_KEYS env is set to an empty string`, () => {
     process.env.COREPACK_INTEGRITY_KEYS = ``;
     expect(shouldSkipIntegrityCheck()).toBe(true);
   });
 
   it(`should return true if COREPACK_INTEGRITY_KEYS env is set to a string with leading spaces`, () => {
-    process.env.COREPACK_INTEGRITY_KEYS = ` false `;
+    process.env.COREPACK_INTEGRITY_KEYS = ` `;
     expect(shouldSkipIntegrityCheck()).toBe(true);
   });
 
   it(`should return false if COREPACK_INTEGRITY_KEYS env is set to any other value`, () => {
-    process.env.COREPACK_INTEGRITY_KEYS = JSON.stringify({ foo: `bar` });
+    process.env.COREPACK_INTEGRITY_KEYS = JSON.stringify({foo: `bar`});
     expect(shouldSkipIntegrityCheck()).toBe(false);
   });
 });

--- a/tests/corepackUtils.test.ts
+++ b/tests/corepackUtils.test.ts
@@ -18,11 +18,6 @@ describe(`corepack utils shouldSkipIntegrityCheck`, () => {
     expect(shouldSkipIntegrityCheck()).toBe(true);
   });
 
-  it(`should return true if COREPACK_INTEGRITY_KEYS env is set to a string with leading spaces`, () => {
-    process.env.COREPACK_INTEGRITY_KEYS = ` `;
-    expect(shouldSkipIntegrityCheck()).toBe(true);
-  });
-
   it(`should return false if COREPACK_INTEGRITY_KEYS env is set to any other value`, () => {
     process.env.COREPACK_INTEGRITY_KEYS = JSON.stringify({foo: `bar`});
     expect(shouldSkipIntegrityCheck()).toBe(false);

--- a/tests/corepackUtils.test.ts
+++ b/tests/corepackUtils.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "@jest/globals";
+
+import { shouldSkipIntegrityCheck } from "../sources/corepackUtils";
+
+describe(`corepack utils shouldSkipIntegrityCheck`, () => {
+  it(`should return false if COREPACK_INTEGRITY_KEYS env is not set`, () => {
+    delete process.env.COREPACK_INTEGRITY_KEYS;
+    expect(shouldSkipIntegrityCheck()).toBe(false);
+  });
+
+  it(`should return true if COREPACK_INTEGRITY_KEYS env is set to 0`, () => {
+    process.env.COREPACK_INTEGRITY_KEYS = `0`;
+    expect(shouldSkipIntegrityCheck()).toBe(true);
+  });
+
+  it(`should return true if COREPACK_INTEGRITY_KEYS env is set to false`, () => {
+    process.env.COREPACK_INTEGRITY_KEYS = `false`;
+    expect(shouldSkipIntegrityCheck()).toBe(true);
+  });
+
+  it(`should return true if COREPACK_INTEGRITY_KEYS env is set to FALSE`, () => {
+    process.env.COREPACK_INTEGRITY_KEYS = `FALSE`;
+    expect(shouldSkipIntegrityCheck()).toBe(true);
+  });
+
+  it(`should return true if COREPACK_INTEGRITY_KEYS env is set to an empty string`, () => {
+    process.env.COREPACK_INTEGRITY_KEYS = ``;
+    expect(shouldSkipIntegrityCheck()).toBe(true);
+  });
+
+  it(`should return true if COREPACK_INTEGRITY_KEYS env is set to a string with leading spaces`, () => {
+    process.env.COREPACK_INTEGRITY_KEYS = ` false `;
+    expect(shouldSkipIntegrityCheck()).toBe(true);
+  });
+
+  it(`should return false if COREPACK_INTEGRITY_KEYS env is set to any other value`, () => {
+    process.env.COREPACK_INTEGRITY_KEYS = JSON.stringify({ foo: `bar` });
+    expect(shouldSkipIntegrityCheck()).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR adds the possibility of setting `COREPACK_INTEGRITY_KEYS` to `0` ~and `false`~ to disable integrity checks.

Fixes: #468 