### PR TITLE
chore(ci): better check for Nocks changes

### DIFF
--- a/.github/workflows/update-nock-files.yml
+++ b/.github/workflows/update-nock-files.yml
@@ -50,13 +50,11 @@ jobs:
       - name: Check if anything has changed
         id: contains-changes
         run: |
-          sqlite3 tests/nocks.db .dump > tests/nocks.sql
-          git add tests/nocks.sql
+          sqlite3 tests/nocks.db .dump > /tmp/before.sql
           cp tests/nocks.db tests/nocks.db.new
           git checkout HEAD -- tests/nocks.db
-          sqlite3 tests/nocks.db .dump > tests/nocks.sql
-          echo "result=$(git --no-pager diff --quiet -- tests/nocks.sql || echo "yes")" >> "$GITHUB_OUTPUT"
-          git rm -f tests/nocks.sql
+          sqlite3 tests/nocks.db .dump > /tmp/after.sql
+          echo "result=$(git --no-pager diff --quiet --no-index /tmp/before.sql /tmp/after.sql || echo "yes")" >> "$GITHUB_OUTPUT"
           mv tests/nocks.db.new tests/nocks.db
         shell: bash
 

--- a/.github/workflows/update-nock-files.yml
+++ b/.github/workflows/update-nock-files.yml
@@ -49,7 +49,15 @@ jobs:
 
       - name: Check if anything has changed
         id: contains-changes
-        run: echo "result=$(git --no-pager diff --quiet -- tests/nocks.db || echo "yes")" >> $GITHUB_OUTPUT
+        run: |
+          sqlite3 tests/nocks.db .dump > tests/nocks.sql
+          git add tests/nocks.sql
+          cp tests/nocks.db tests/nocks.db.new
+          git checkout HEAD -- tests/nocks.db
+          sqlite3 tests/nocks.db .dump > tests/nocks.sql
+          echo "result=$(git --no-pager diff --quiet -- tests/nocks.sql || echo "yes")" >> "$GITHUB_OUTPUT"
+          git rm -f tests/nocks.sql
+          mv tests/nocks.db.new tests/nocks.db
         shell: bash
 
       - name: Commit changes


### PR DESCRIPTION
When there are no changes, asking Git to compare the db file directly will always report change even though the actual data stored is the same. Instead, we can compare a SQL dump to detect actual changes.