### PR TITLE
fix: replace npm registry domain in tarball URL

### DIFF
--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -230,12 +230,11 @@ export async function installVersion(installTarget: string, locator: Locator, {s
         if (registry.bin) {
           binPath = registry.bin;
         }
-      } else {
-        url = url.replace(
-          npmRegistryUtils.DEFAULT_NPM_REGISTRY_URL,
-          () => process.env.COREPACK_NPM_REGISTRY!,
-        );
       }
+      url = url.replace(
+        npmRegistryUtils.DEFAULT_NPM_REGISTRY_URL,
+        () => process.env.COREPACK_NPM_REGISTRY!,
+      );
     }
   } else {
     url = decodeURIComponent(version);

--- a/tests/_registryServer.mjs
+++ b/tests/_registryServer.mjs
@@ -104,7 +104,7 @@ function generateVersionMetadata(packageName, version) {
       shasum,
       size: mockPackageTarGz.length,
       noattachment: false,
-      tarball: `${process.env.COREPACK_NPM_REGISTRY}/${packageName}/-/${packageName}-${version}.tgz`,
+      tarball: `https://registry.npmjs.org/${packageName}/-/${packageName}-${version}.tgz`,
       ...generateSignature(packageName, version),
     },
   };


### PR DESCRIPTION
Not all proxies rewrite the tarball URL, and expect the client to do so.

Fixes: https://github.com/nodejs/corepack/issues/498