### PR TITLE
fix: custom registry with path after base url

### DIFF
--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -20,20 +20,19 @@ async function fetch(input: string | URL, init?: RequestInit) {
   const username: string | undefined = input.username || process.env.COREPACK_NPM_USERNAME;
   const password: string | undefined = input.password || process.env.COREPACK_NPM_PASSWORD;
 
-  if (username || password) {
+  if (process.env.COREPACK_NPM_TOKEN) {
+    headers =  {
+      ...headers,
+      authorization: `Bearer ${process.env.COREPACK_NPM_TOKEN}`,
+    };
+  }
+  else if (username && password) {
     headers =  {
       ...headers,
       authorization: `Basic ${Buffer.from(`${username}:${password}`).toString(`base64`)}`,
     };
 
     input.username = input.password = ``;
-  }
-
-  if (input.origin === (process.env.COREPACK_NPM_REGISTRY || DEFAULT_NPM_REGISTRY_URL) && process.env.COREPACK_NPM_TOKEN) {
-    headers =  {
-      ...headers,
-      authorization: `Bearer ${process.env.COREPACK_NPM_TOKEN}`,
-    };
   }
 
   let response;

--- a/sources/npmRegistryUtils.ts
+++ b/sources/npmRegistryUtils.ts
@@ -20,15 +20,7 @@ export async function fetchAsJson(packageName: string, version?: string) {
     throw new UsageError(`Network access disabled by the environment; can't reach npm repository ${npmRegistryUrl}`);
 
   const headers = {...DEFAULT_HEADERS};
-
-  if (`COREPACK_NPM_TOKEN` in process.env) {
-    headers.authorization = `Bearer ${process.env.COREPACK_NPM_TOKEN}`;
-  } else if (`COREPACK_NPM_USERNAME` in process.env
-          && `COREPACK_NPM_PASSWORD` in process.env) {
-    const encodedCreds = Buffer.from(`${process.env.COREPACK_NPM_USERNAME}:${process.env.COREPACK_NPM_PASSWORD}`, `utf8`).toString(`base64`);
-    headers.authorization = `Basic ${encodedCreds}`;
-  }
-
+  
   return httpUtils.fetchAsJson(`${npmRegistryUrl}/${packageName}${version ? `/${version}` : ``}`, {headers});
 }
 

--- a/tests/httpUtils.test.ts
+++ b/tests/httpUtils.test.ts
@@ -1,0 +1,29 @@
+import {jest, describe, beforeEach, it, expect}                 from '@jest/globals';
+import process                                                  from 'node:process';
+import {fetchAsJson as httpFetchAsJson}                         from '../sources/httpUtils';
+
+describe(`httpUtils`, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    globalThis.fetch = jest.fn(() => Promise.resolve( {
+      ok: true,
+      json: () => Promise.resolve({})
+    }));
+  });
+
+  it(`adds authorization header if COREPACK_NPM_TOKEN is set with custom COREPACK_NPM_REGISTRY`, async () => {
+    // `process.env` is reset after each tests in setupTests.js.
+    process.env.COREPACK_NPM_TOKEN = `foo`;
+    process.env.COREPACK_NPM_REGISTRY = `https://registry.example.org/with-path/npm`
+
+    await httpFetchAsJson(`${process.env.COREPACK_NPM_REGISTRY}/package-name`);
+
+    expect(globalThis.fetch).toBeCalled();
+    expect(globalThis.fetch).lastCalledWith(new URL(`${process.env.COREPACK_NPM_REGISTRY}/package-name`), {
+      headers: {
+        authorization: `Bearer ${process.env.COREPACK_NPM_TOKEN}`,
+      }});
+  });
+
+});


### PR DESCRIPTION
when using a custom registry with a path after the base URL (like `https://registry.example.org/with-path/npm`) and using COREPACK_NPM_TOKEN corepack would not set the Bearer token correctly for the file download (it did set it for downloading jsons).

while fixing it I also saw that the logic for setting the bearer token was duplicated. I removed the duplicated logic, always setting the bearer in the same place and removed the strange condition for checking the origin (it is not checked when using username password, why then check when using the token?)

some additional minor changes make the code intent clearer IMHO

let me know if I missed something