### PR TITLE
chore: selectively import required semver functions

### DIFF
--- a/genlist.ts
+++ b/genlist.ts
@@ -1,10 +1,10 @@
 import {readFileSync} from 'fs';
-import semver         from 'semver';
+import semverCompare  from 'semver/functions/compare';
 
 const lines = readFileSync(0, `utf8`).split(/\n/).filter(line => line);
 
 lines.sort((a, b) => {
-  return semver.compare(a, b);
+  return semverCompare(a, b);
 });
 
 for (const version of lines)

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -2,7 +2,9 @@ import {UsageError}                                           from 'clipanion';
 import fs                                                     from 'fs';
 import path                                                   from 'path';
 import process                                                from 'process';
-import semver                                                 from 'semver';
+import semverRcompare                                         from 'semver/functions/rcompare';
+import semverValid                                            from 'semver/functions/valid';
+import semverValidRange                                       from 'semver/ranges/valid';
 
 import defaultConfig                                          from '../config.json';
 
@@ -334,7 +336,7 @@ export class Engine {
       throw new UsageError(`This package manager (${descriptor.name}) isn't supported by this corepack build`);
 
     let finalDescriptor = descriptor;
-    if (!semver.valid(descriptor.range) && !semver.validRange(descriptor.range)) {
+    if (!semverValid(descriptor.range) && !semverValidRange(descriptor.range)) {
       if (!allowTags)
         throw new UsageError(`Packages managers can't be referenced via tags in this context`);
 
@@ -363,7 +365,7 @@ export class Engine {
 
     // If the user asked for a specific version, no need to request the list of
     // available versions from the registry.
-    if (semver.valid(finalDescriptor.range))
+    if (semverValid(finalDescriptor.range))
       return {name: finalDescriptor.name, reference: finalDescriptor.range};
 
     const versions = await Promise.all(Object.keys(definition.ranges).map(async range => {
@@ -374,7 +376,7 @@ export class Engine {
       return versions.filter(version => semverUtils.satisfiesWithPrereleases(version, finalDescriptor.range));
     }));
 
-    const highestVersion = [...new Set(versions.flat())].sort(semver.rcompare);
+    const highestVersion = [...new Set(versions.flat())].sort(semverRcompare);
     if (highestVersion.length === 0)
       return null;
 

--- a/sources/commands/Up.ts
+++ b/sources/commands/Up.ts
@@ -1,5 +1,7 @@
 import {Command, UsageError}           from 'clipanion';
-import semver                          from 'semver';
+import semverMajor                     from 'semver/functions/major';
+import semverValid                     from 'semver/functions/valid';
+import semverValidRange                from 'semver/ranges/valid';
 
 import type {SupportedPackageManagers} from '../types';
 
@@ -33,14 +35,14 @@ export class UpCommand extends BaseCommand {
       patterns: [],
     });
 
-    if (!semver.valid(descriptor.range) && !semver.validRange(descriptor.range))
+    if (!semverValid(descriptor.range) && !semverValidRange(descriptor.range))
       throw new UsageError(`The 'corepack up' command can only be used when your project's packageManager field is set to a semver version or semver range`);
 
     const resolved = await this.context.engine.resolveDescriptor(descriptor, {useCache: false});
     if (!resolved)
       throw new UsageError(`Failed to successfully resolve '${descriptor.range}' to a valid ${descriptor.name} release`);
 
-    const majorVersion = semver.major(resolved.reference);
+    const majorVersion = semverMajor(resolved.reference);
     const majorDescriptor = {name: descriptor.name as SupportedPackageManagers, range: `^${majorVersion}.0.0`};
 
     const highestVersion = await this.context.engine.resolveDescriptor(majorDescriptor, {useCache: false});

--- a/sources/semverUtils.ts
+++ b/sources/semverUtils.ts
@@ -1,4 +1,5 @@
-import semver from 'semver';
+import Range  from 'semver/classes/range';
+import SemVer from 'semver/classes/semver';
 
 /**
  * Returns whether the given semver version satisfies the given range. Notably
@@ -16,7 +17,7 @@ import semver from 'semver';
 export function satisfiesWithPrereleases(version: string | null, range: string, loose: boolean = false): boolean {
   let semverRange;
   try {
-    semverRange = new semver.Range(range, loose);
+    semverRange = new Range(range, loose);
   } catch (err) {
     return false;
   }
@@ -24,9 +25,9 @@ export function satisfiesWithPrereleases(version: string | null, range: string, 
   if (!version)
     return false;
 
-  let semverVersion: semver.SemVer;
+  let semverVersion: SemVer;
   try {
-    semverVersion = new semver.SemVer(version, semverRange.loose);
+    semverVersion = new SemVer(version, semverRange.loose);
     if (semverVersion.prerelease) {
       semverVersion.prerelease = [];
     }

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -1,7 +1,7 @@
 import {UsageError}                            from 'clipanion';
 import fs                                      from 'fs';
 import path                                    from 'path';
-import semver                                  from 'semver';
+import semverValid                             from 'semver/functions/valid';
 
 import {PreparedPackageManagerInfo}            from './Engine';
 import {NodeError}                             from './nodeUtils';
@@ -34,7 +34,7 @@ export function parseSpec(raw: unknown, source: string, {enforceExactVersion = t
 
   const isURL = URL.canParse(range);
   if (!isURL) {
-    if (enforceExactVersion && !semver.valid(range))
+    if (enforceExactVersion && !semverValid(range))
       throw new UsageError(`Invalid package manager specification in ${source} (${raw}); expected a semver version${enforceExactVersion ? `` : `, range, or tag`}`);
 
     if (!isSupportedPackageManager(name)) {


### PR DESCRIPTION
By selectively importing only the functions we want, we avoid bundling in the entire semver package, which results in impressive savings of roughly 25 KB.

Before:
```
wmaj@MacBook-Air corepack % yarn build

  dist/lib/corepack.cjs  949.5kb
```

After:
```
wmaj@MacBook-Air corepack % yarn build

  dist/lib/corepack.cjs  924.7kb
```

It also (minimally) reduces execution time:

```
Benchmark 1: node dist/lib/corepack_before.cjs
  Time (mean ± σ):      43.9 ms ±   5.1 ms    [User: 38.9 ms, System: 4.1 ms]
  Range (min … max):    42.1 ms …  83.5 ms    65 runs
 
Benchmark 2: node dist/lib/corepack_after.cjs
  Time (mean ± σ):      42.8 ms ±   4.7 ms    [User: 37.9 ms, System: 4.1 ms]
  Range (min … max):    40.7 ms …  80.6 ms    67 runs
 
Summary
  node dist/lib/corepack_after.cjs ran
    1.03 ± 0.16 times faster than node dist/lib/corepack_before.cjs
```