### PR TITLE
chore: bump better-sqlite3 to 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@yarnpkg/fslib": "^3.0.0-rc.48",
     "@zkochan/cmd-shim": "^6.0.0",
     "babel-plugin-dynamic-import-node": "^2.3.3",
-    "better-sqlite3": "^9.4.1",
+    "better-sqlite3": "^10.0.0",
     "clipanion": "^3.0.1",
     "debug": "^4.1.1",
     "esbuild": "0.19.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,14 +1891,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^9.4.1":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
+"better-sqlite3@npm:^10.0.0":
+  version: 10.1.0
+  resolution: "better-sqlite3@npm:10.1.0"
   dependencies:
     bindings: "npm:^1.5.0"
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
-  checksum: 10c0/8db9b38f414e26a56d4c40fc16e94a253118491dae0e2c054338a9e470f1a883c7eb4cb330f2f5737db30f704d4f2e697c59071ca04e03364ee9fe04375aa9c8
+  checksum: 10c0/3c858214b8b6f0c3f536759a863dfc79b11c52cecd6061525fb7707d950ea2ef369280276d8cc62d504119514b7d32ea4aab134d260f6b5a0419a8119d613a67
   languageName: node
   linkType: hard
 
@@ -2224,7 +2224,7 @@ __metadata:
     "@yarnpkg/fslib": "npm:^3.0.0-rc.48"
     "@zkochan/cmd-shim": "npm:^6.0.0"
     babel-plugin-dynamic-import-node: "npm:^2.3.3"
-    better-sqlite3: "npm:^9.4.1"
+    better-sqlite3: "npm:^10.0.0"
     clipanion: "npm:^3.0.1"
     debug: "npm:^4.1.1"
     esbuild: "npm:0.19.5"


### PR DESCRIPTION
Why bump from 9.x:
better-sqlite3 v9 fails to install on macOS and Node.js 22, which as an upcoming LTS version is likely going to become a primary development tool for contributors.

Why bump to 10.x:
Fixed support for macOS and Node.js 22, general evergreening.

Why bump to 10.x and not 11.x:
better-sqlite3 v11 drops support for Node.js 21.