### PR TITLE
chore: add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.DS_Store
 
 /.yarn/*
 !/.yarn/cache


### PR DESCRIPTION
For macOS contributors, .DS_Store keeps appearing in diffs and prevents the use of `git add .`, which is a major pain in the butt when contributing.