### PR TITLE
chore: use renameSafe where applicable

### DIFF
--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -305,11 +305,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
 
   await fs.promises.mkdir(path.dirname(installFolder), {recursive: true});
   try {
-    if (process.platform === `win32`) {
-      await renameUnderWindows(tmpFolder, installFolder);
-    } else {
-      await fs.promises.rename(tmpFolder, installFolder);
-    }
+    renameSafe(tmpFolder, installFolder);
   } catch (err) {
     if (
       (err as nodeUtils.NodeError).code === `ENOTEMPTY` ||

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -305,7 +305,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
 
   await fs.promises.mkdir(path.dirname(installFolder), {recursive: true});
   try {
-    renameSafe(tmpFolder, installFolder);
+    await renameSafe(tmpFolder, installFolder);
   } catch (err) {
     if (
       (err as nodeUtils.NodeError).code === `ENOTEMPTY` ||


### PR DESCRIPTION
Code I removed is literally renameSafe's body, so I replaced it with renameSafe.