### PR TITLE
chore(ci): test on Node.js 22.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           - 18
           - 20
           - 21
+          - 22
         platform:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
With Node.js 22 quickly getting closer to LTS, we should be testing Corepack using it.