### PR TITLE
chore(ci): pass `NPM_TOKEN` to `npm publish` step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Publish to the npm registry
         run: npm publish corepack.tgz --provenance
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Add Corepack package archive to GitHub release
         run: gh release upload ${{ needs.release-please.outputs.release_tag }} corepack.tgz


### PR DESCRIPTION
I suggested to use `NODE_AUTH_TOKEN` because that's what was used in https://github.com/nodejs/undici/blob/1a6ab5f61e62a02fc5a0f1da88f1c9973f0baa61/.github/workflows/release.yml#L67, but it looks like that's not working for us. https://github.com/nodejs/remark-preset-lint-node/blob/a99e968ef22cf09bfa9088e7a5d4ff589bfdc2d8/.github/workflows/test-and-release.yml#L67 is using `NPM_TOKEN`, that might be a better choice.