### PR TITLE
Revert "chore(ci): pass `NPM_TOKEN` to `npm publish` step"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Publish to the npm registry
         run: npm publish corepack.tgz --provenance
         env:
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Add Corepack package archive to GitHub release
         run: gh release upload ${{ needs.release-please.outputs.release_tag }} corepack.tgz


### PR DESCRIPTION
Reverts nodejs/corepack#527 to fix the release workflow 