### PR TITLE
chore(deps): bump semver from 7.6.2 to 7.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "esbuild": "^0.21.0",
     "eslint": "^8.57.0",
     "proxy-from-env": "^1.1.0",
-    "semver": "^7.5.2",
+    "semver": "^7.6.3",
     "supports-color": "^9.0.0",
     "tar": "^6.2.1",
     "tsx": "^4.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1230,7 +1230,7 @@ __metadata:
     esbuild: "npm:^0.21.0"
     eslint: "npm:^8.57.0"
     proxy-from-env: "npm:^1.1.0"
-    semver: "npm:^7.5.2"
+    semver: "npm:^7.6.3"
     supports-color: "npm:^9.0.0"
     tar: "npm:^6.2.1"
     tsx: "npm:^4.16.2"
@@ -1286,19 +1286,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
-  version: 4.3.4
-  resolution: "debug@npm:4.3.4"
-  dependencies:
-    ms: "npm:2.1.2"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10c0/cedbec45298dd5c501d01b92b119cd3faebe5438c3917ff11ae1bff86a6c722930ac9c8659792824013168ba6db7c4668225d845c633fbdafbbf902a6389f736
-  languageName: node
-  linkType: hard
-
-"debug@npm:^4.3.5":
+"debug@npm:4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5":
   version: 4.3.5
   resolution: "debug@npm:4.3.5"
   dependencies:
@@ -3671,12 +3659,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.6.0":
-  version: 7.6.2
-  resolution: "semver@npm:7.6.2"
+"semver@npm:^7.3.5, semver@npm:^7.6.0, semver@npm:^7.6.3":
+  version: 7.6.3
+  resolution: "semver@npm:7.6.3"
   bin:
     semver: bin/semver.js
-  checksum: 10c0/97d3441e97ace8be4b1976433d1c32658f6afaff09f143e52c593bae7eef33de19e3e369c88bd985ce1042c6f441c80c6803078d1de2a9988080b66684cbb30c
+  checksum: 10c0/88f33e148b210c153873cb08cfe1e281d518aaa9a666d4d148add6560db5cd3c582f3a08ccb91f38d5f379ead256da9931234ed122057f40bb5766e65e58adaf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bugfix version of semver includes significant performance improvements that I guess we would like to see in corepack.

See: https://github.com/npm/node-semver/pull/726