### PR TITLE
fix: make `DEBUG=corepack` more useful

### DIFF
--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -207,7 +207,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
 
     const corepackData = JSON.parse(corepackContent);
 
-    debugUtils.log(`Reusing ${locator.name}@${locator.reference}`);
+    debugUtils.log(`Reusing ${locator.name}@${locator.reference} found in ${installFolder}`);
 
     return {
       hash: corepackData.hash as string,
@@ -333,7 +333,7 @@ export async function installVersion(installTarget: string, locator: Locator, {s
     }
   }
 
-  debugUtils.log(`Install finished`);
+  debugUtils.log(`Download and install of ${locator.name}@${locator.reference} is finished`);
 
   return {
     location: installFolder,

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -4,6 +4,7 @@ import path                                    from 'path';
 import semverValid                             from 'semver/functions/valid';
 
 import {PreparedPackageManagerInfo}            from './Engine';
+import * as debugUtils                         from './debugUtils';
 import {NodeError}                             from './nodeUtils';
 import * as nodeUtils                          from './nodeUtils';
 import {Descriptor, isSupportedPackageManager} from './types';
@@ -93,6 +94,7 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
       continue;
 
     const manifestPath = path.join(currCwd, `package.json`);
+    debugUtils.log(`Checking ${manifestPath}`);
     let content: string;
     try {
       content = await fs.promises.readFile(manifestPath, `utf8`);


### PR DESCRIPTION
Sometimes it can be hard to understand why Corepack behaves the way it does. IMO `DEBUG=corepack` should be more verbose than it currently is, so anyone can follow along e.g. why/how Corepack selects the version of the requested package manager.