### PR TITLE
fix: fallback to `shasum` when `integrity` is not defined

### DIFF
--- a/sources/npmRegistryUtils.ts
+++ b/sources/npmRegistryUtils.ts
@@ -73,9 +73,9 @@ export async function fetchLatestStableVersion(packageName: string) {
 
   return `${version}+${
     integrity ?
-     `sha512.${Buffer.from(integrity.slice(7), `base64`).toString(`hex`)}`:
-     `sha1.${shasum}`
-    }`;
+      `sha512.${Buffer.from(integrity.slice(7), `base64`).toString(`hex`)}` :
+      `sha1.${shasum}`
+  }`;
 }
 
 export async function fetchAvailableTags(packageName: string) {

--- a/sources/npmRegistryUtils.ts
+++ b/sources/npmRegistryUtils.ts
@@ -62,7 +62,7 @@ export function verifySignature({signatures, integrity, packageName, version}: {
 export async function fetchLatestStableVersion(packageName: string) {
   const metadata = await fetchAsJson(packageName, `latest`);
 
-  const {version, dist: {integrity, signatures}} = metadata;
+  const {version, dist: {integrity, signatures, shasum}} = metadata;
 
   if (!shouldSkipIntegrityCheck()) {
     verifySignature({
@@ -71,7 +71,11 @@ export async function fetchLatestStableVersion(packageName: string) {
     });
   }
 
-  return `${version}+sha512.${Buffer.from(integrity.slice(7), `base64`).toString(`hex`)}`;
+  return `${version}+${
+    integrity ?
+     `sha512.${Buffer.from(integrity.slice(7), `base64`).toString(`hex`)}`:
+     `sha1.${shasum}`
+    }`;
 }
 
 export async function fetchAvailableTags(packageName: string) {

--- a/tests/_registryServer.mjs
+++ b/tests/_registryServer.mjs
@@ -88,6 +88,7 @@ function generateSignature(packageName, version) {
   if (privateKey == null) return undefined;
   const sign = createSign(`SHA256`).end(`${packageName}@${version}:${integrity}`);
   return {signatures: [{
+    integrity,
     keyid,
     sig: sign.sign(privateKey, `base64`),
   }]};
@@ -100,10 +101,8 @@ function generateVersionMetadata(packageName, version) {
       [packageName]: `./bin/${packageName}.js`,
     },
     dist: {
-      integrity,
       shasum,
       size: mockPackageTarGz.length,
-      noattachment: false,
       tarball: `https://registry.npmjs.org/${packageName}/-/${packageName}-${version}.tgz`,
       ...generateSignature(packageName, version),
     },

--- a/tests/_registryServer.mjs
+++ b/tests/_registryServer.mjs
@@ -87,8 +87,7 @@ const registry = {
 function generateSignature(packageName, version) {
   if (privateKey == null) return undefined;
   const sign = createSign(`SHA256`).end(`${packageName}@${version}:${integrity}`);
-  return {signatures: [{
-    integrity,
+  return {integrity, signatures: [{
     keyid,
     sig: sign.sign(privateKey, `base64`),
   }]};

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -899,7 +899,7 @@ it(`should download latest pnpm from custom registry`, async () => {
     await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
       exitCode: 0,
       stdout: `pnpm: Hello from custom registry\n`,
-      stderr: /^! The local project doesn't define a 'packageManager' field\. Corepack will now add one referencing pnpm@1\.9998\.9999/,
+      stderr: /^! The local project doesn't define a 'packageManager' field\. Corepack will now add one referencing pnpm@1\.9998\.9999@sha1\./,
     });
 
     // Should keep working with cache

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -899,9 +899,7 @@ it(`should download latest pnpm from custom registry`, async () => {
     await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
       exitCode: 0,
       stdout: `pnpm: Hello from custom registry\n`,
-      stderr:
-        `! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@1.9998.9999+sha1.d862ca5bedaa7d2328b8bde6ce2bac5141681f48.\n` +
-        `! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager\n\n`,
+      stderr: /^! The local project doesn't define a 'packageManager' field\. Corepack will now add one referencing pnpm@1\.9998\.9999/,
     });
 
     // Should keep working with cache

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -887,6 +887,32 @@ it(`should download yarn berry from custom registry`, async () => {
   });
 });
 
+it(`should download latest pnpm from custom registry`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    process.env.AUTH_TYPE = `COREPACK_NPM_TOKEN`; // See `_registryServer.mjs`
+    process.env.COREPACK_DEFAULT_TO_LATEST = `1`;
+    process.env.COREPACK_INTEGRITY_KEYS = `0`;
+
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
+    });
+
+    await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: `pnpm: Hello from custom registry\n`,
+      stderr: 
+        `! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@1.9998.9999+sha1.d862ca5bedaa7d2328b8bde6ce2bac5141681f48.\n` +
+        `! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager\n`,
+    });
+
+    // Should keep working with cache
+    await expect(runCli(cwd, [`pnpm`, `--version`])).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: `pnpm: Hello from custom registry\n`,
+      stderr: ``,
+    });
+  });
+});
+
 for (const authType of [`COREPACK_NPM_REGISTRY`, `COREPACK_NPM_TOKEN`, `COREPACK_NPM_PASSWORD`, `PROXY`]) {
   describe(`custom registry with auth ${authType}`, () => {
     beforeEach(() => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -899,7 +899,7 @@ it(`should download latest pnpm from custom registry`, async () => {
     await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
       exitCode: 0,
       stdout: `pnpm: Hello from custom registry\n`,
-      stderr: 
+      stderr:
         `! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@1.9998.9999+sha1.d862ca5bedaa7d2328b8bde6ce2bac5141681f48.\n` +
         `! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager\n\n`,
     });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -901,7 +901,7 @@ it(`should download latest pnpm from custom registry`, async () => {
       stdout: `pnpm: Hello from custom registry\n`,
       stderr: 
         `! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@1.9998.9999+sha1.d862ca5bedaa7d2328b8bde6ce2bac5141681f48.\n` +
-        `! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager\n`,
+        `! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager\n\n`,
     });
 
     // Should keep working with cache


### PR DESCRIPTION
Some npm registries do not define an `integrity` field, in which case we can try using the `shasum` field instead.

Fixes: https://github.com/nodejs/corepack/issues/537