### PR TITLE
Allow node v20+

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/nodejs/corepack.git"
   },
   "engines": {
-    "node": "^18.17.1 || >=20.10.0"
+    "node": "^18.17.1 || >=20"
   },
   "exports": {
     "./package.json": "./package.json"


### PR DESCRIPTION
This was added in 9a1cb385bba9ade8e9fbf5517c2bdff60295f9ed when dropping support for node v19, but I can't see any reason why for instance node v20.5.0 should be excluded.