### PR TITLE
add `corepack project install` command

### DIFF
--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -32,6 +32,10 @@ export abstract class BaseCommand extends Command<Context> {
       previousPackageManager,
     } = await specUtils.setLocalPackageManager(this.context.cwd, info);
 
+    await this.installLocalPackageManager(info, previousPackageManager);
+  }
+
+  async installLocalPackageManager(info: PreparedPackageManagerInfo, previousPackageManager?: string) {
     const command = this.context.engine.getPackageManagerSpecFor(info.locator).commands?.use ?? null;
     if (command === null)
       return 0;

--- a/sources/commands/Project.ts
+++ b/sources/commands/Project.ts
@@ -1,0 +1,46 @@
+import {Command, UsageError} from 'clipanion';
+import semverValid           from 'semver/functions/valid';
+import semverValidRange      from 'semver/ranges/valid';
+
+import {BaseCommand}         from './Base';
+
+// modified from ./Enable.ts
+// https://github.com/nodejs/corepack/issues/505
+export class ProjectInstallCommand extends BaseCommand {
+  static paths = [
+    [`project`, `install`],
+  ];
+
+  static usage = Command.Usage({
+    description: `Add the Corepack shims to the install directories, and run the install command of the specified package manager`,
+    details: `
+      When run, this command will check whether the shims for the specified package managers can be found with the correct values inside the install directory. If not, or if they don't exist, they will be created.
+
+      Then, it will run the install command of the specified package manager. If no package manager is specified, it will default to NPM.
+
+      By default it will locate the install directory by running the equivalent of \`which corepack\`, but this can be tweaked by explicitly passing the install directory via the \`--install-directory\` flag.
+    `,
+    examples: [[
+      `Enable all shims and install, putting shims next to the \`corepack\` binary`,
+      `$0 project install`,
+    ]],
+  });
+
+  async execute() {
+    const [descriptor] = await this.resolvePatternsToDescriptors({
+      patterns: [],
+    });
+
+    if (!semverValid(descriptor.range) && !semverValidRange(descriptor.range))
+      throw new UsageError(`The 'corepack project install' command can only be used when your project's packageManager field is set to a semver version or semver range`);
+
+    const resolved = await this.context.engine.resolveDescriptor(descriptor, {useCache: true});
+    if (!resolved)
+      throw new UsageError(`Failed to successfully resolve '${descriptor.range}' to a valid ${descriptor.name} release`);
+
+    this.context.stdout.write(`Installing ${resolved.name}@${resolved.reference} in the project...\n`);
+
+    const packageManagerInfo = await this.context.engine.ensurePackageManager(resolved);
+    await this.installLocalPackageManager(packageManagerInfo);
+  }
+}

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -9,6 +9,7 @@ import {EnableCommand}                 from './commands/Enable';
 import {InstallGlobalCommand}          from './commands/InstallGlobal';
 import {InstallLocalCommand}           from './commands/InstallLocal';
 import {PackCommand}                   from './commands/Pack';
+import {ProjectInstallCommand}         from './commands/Project';
 import {UpCommand}                     from './commands/Up';
 import {UseCommand}                    from './commands/Use';
 import {HydrateCommand}                from './commands/deprecated/Hydrate';
@@ -62,6 +63,7 @@ export async function runMain(argv: Array<string>) {
     cli.register(PackCommand);
     cli.register(UpCommand);
     cli.register(UseCommand);
+    cli.register(ProjectInstallCommand);
 
     // Deprecated commands
     cli.register(HydrateCommand);

--- a/tests/Project.test.ts
+++ b/tests/Project.test.ts
@@ -1,0 +1,9 @@
+import {describe, it} from 'vitest';
+
+describe(`ProjectCommand`, () => {
+  describe(`InstallSubcommand`, () => {
+    it(`should add the binaries in the folder found in the PATH`, async () => {
+      // todo
+    });
+  });
+});


### PR DESCRIPTION
Closes #505

This adds a `corepack project install` command, which is roughly equivalent to

- `corepack enable && npm install` for npm projects
- `corepack enable && pnpm install` for pnpm projects
- `corepack enable && yarn install` for yarn projects

I was able to use it successfully by just running `yarn build` locally, then I could do `node dist/corepack.js project install` to verify it works on the corepack repo itself, and `node ../corepack/dist/corepack.js project install` from various git repos next door.

I wanted to open this up early to get feedback in case the direction isn't considered correct. If it's looking good, I will add tests along similar lines to the existing ones.

Some follow-ons (which I think could be implemented as separate PRs, but could be persuaded to roll them into this one)

- Common CLI args that all the package managers support:
   - `--frozen-lockfile` and `--no-frozen-lockfile`
   - `--lockfile-only`
   - `--no-lockfile`
   - `--production`
   - `--dev`
   - `--offline`
   - `--force`
- Other subcommands:
   - `corepack project add left-pad`
   - `corepack project remove left-pad`

CC @styfle and @aduh95 since you commented on the issue.