### PR TITLE
Do not auto pin by default COREPACK_ENABLE_AUTO_PIN=0 is now the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ same major line. Should you need to upgrade to a new major, use an explicit
   package manager, and to not update the Last Known Good version when it
   downloads a new version of the same major line.
 
-- `COREPACK_ENABLE_AUTO_PIN` can be set to `0` to prevent Corepack from
-  updating the `packageManager` field when it detects that the local package
+- `COREPACK_ENABLE_AUTO_PIN` can be set to `1` to allow Corepack to
+  update the `packageManager` field when it detects that the local package
   doesn't list it. In general we recommend to always list a `packageManager`
   field (which you can easily set through `corepack use [name]@[version]`), as
   it ensures that your project installs are always deterministic.

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -263,7 +263,7 @@ export class Engine {
           return fallbackDescriptor;
 
         case `NoSpec`: {
-          if (process.env.COREPACK_ENABLE_AUTO_PIN !== `0`) {
+          if (process.env.COREPACK_ENABLE_AUTO_PIN === `1`) {
             const resolved = await this.resolveDescriptor(fallbackDescriptor, {allowTags: true});
             if (resolved === null)
               throw new UsageError(`Failed to successfully resolve '${fallbackDescriptor.range}' to a valid ${fallbackDescriptor.name} release`);
@@ -275,9 +275,11 @@ export class Engine {
             console.error();
 
             await specUtils.setLocalPackageManager(path.dirname(result.target), installSpec);
+          } else {
+            debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in the absence of "packageManage" field in ${result.target}.`);
+            debugUtils.log(`It could be added for you automatically by setting the environment variable COREPACK_ENABLE_AUTO_PIN=1`);
+            debugUtils.log(`For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager`);
           }
-
-          debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in the absence of "packageManage" field in ${result.target}`);
           return fallbackDescriptor;
         }
 

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -276,7 +276,7 @@ export class Engine {
 
             await specUtils.setLocalPackageManager(path.dirname(result.target), installSpec);
           } else {
-            debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in the absence of "packageManage" field in ${result.target}.`);
+            debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in the absence of "packageManager" field in ${result.target}.`);
             debugUtils.log(`It could be added for you automatically by setting the environment variable COREPACK_ENABLE_AUTO_PIN=1`);
             debugUtils.log(`For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager`);
           }


### PR DESCRIPTION
This fixes all issues related to auto-pin mentioned in  #485.