### PR TITLE
chore: fix `sync.yml` permissions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   fetch-latest-versions:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The recent runs are failing because of a permission error.