### PR TITLE
doc: update directories to directory in corepack --help

### DIFF
--- a/sources/commands/Enable.ts
+++ b/sources/commands/Enable.ts
@@ -13,7 +13,7 @@ export class EnableCommand extends Command<Context> {
   ];
 
   static usage = Command.Usage({
-    description: `Add the Corepack shims to the install directories`,
+    description: `Add the Corepack shims to the install directory`,
     details: `
       When run, this command will check whether the shims for the specified package managers can be found with the correct values inside the install directory. If not, or if they don't exist, they will be created.
 


### PR DESCRIPTION
As option `--install-directory` is a single specified directory, so the command description is better to be `directory`

```
━━━ General commands ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  corepack disable [--install-directory #0] ...
    Remove the Corepack shims from the install directory

  corepack enable [--install-directory #0] ...
    Add the Corepack shims to the install directories

  corepack hydrate [--activate] <fileName>
    Import a package manager into the cache

  corepack prepare [--activate] [--all] [--json] [-o,--output] ...
    Generate a package manager archive

You can also print more details about any of these commands by calling them with
the `-h,--help` flag right after the command name.
```