### PR TITLE
perf: use module.enableCompileCache in NodeJS v22

### DIFF
--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -403,9 +403,11 @@ export async function runVersion(locator: Locator, installSpec: InstallSpec & {s
   // Node.js segfaults when using npm@>=9.7.0 and v8-compile-cache
   // $ docker run -it node:20.3.0-slim corepack npm@9.7.1 --version
   // [SIGSEGV]
-  if (locator.name !== `npm` || semverLt(locator.reference, `9.7.0`))
-    // @ts-expect-error - No types
-    await import(`v8-compile-cache`);
+  if (locator.name !== `npm` || semverLt(locator.reference, `9.7.0`)) {
+    if (!Module.enableCompileCache?.())
+      // @ts-expect-error - No types
+      await import(`v8-compile-cache`);
+  }
 
   // We load the binary into the current process,
   // while making it think it was spawned.


### PR DESCRIPTION
Reference API: https://nodejs.org/docs/latest/api/module.html#module-compile-cache