### PR TITLE
chore: add pull_requests: write permissions to sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -10,6 +10,7 @@ jobs:
   fetch-latest-versions:
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- prerequisite to close issue https://github.com/nodejs/corepack/issues/590

## Issue

The workflow [Version Sync](https://github.com/nodejs/corepack/actions/workflows/sync.yml) that keeps pinned versions up-to-date fails with

> Error: Resource not accessible by integration

## Change

Add the following permissions to [Version Sync (sync.yml)](https://github.com/nodejs/corepack/actions/workflows/sync.yml)

```yml
    permissions:
      pull-requests: write
```

## Verification

Run the [Version Sync](https://github.com/nodejs/corepack/actions/workflows/sync.yml) manually and check that it run successfully. It should create a PR to update [config.json](https://github.com/nodejs/corepack/blob/main/config.json) to latest versions:

| Package Manager | `config` version | `latest` version |
| --------------- | ---------------- | ---------------- |
| npm             | `10.9.1`         | `11.0.0`         |
| pnpm            | `9.14.2`         | `9.15.3`         |
| yarn            | `4.5.2`          | `4.6.0`          |

## Additional step

Review and merge the PR created.
