### PR TITLE
chore!: remove Node.js 21.x from the range of supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,18 @@ jobs:
           - 18
           - 20
           - 22
+          - 23
         platform:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+
+      # Temporarily skipping Node.js 23 under Windows due to issue
+      # https://github.com/nodejs/corepack/issues/597
+      # ci vitest fails "handle integrity checks" on Windows Node.js 23
+        exclude:
+          - node: 23
+            platform: windows-latest
 
     name: "${{matrix.platform}} w/ Node.js ${{matrix.node}}.x"
     runs-on: ${{matrix.platform}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
         node:
           - 18
           - 20
-          - 21
           - 22
         platform:
           - ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@yarnpkg/eslint-config": "^2.0.0",
     "@yarnpkg/fslib": "^3.0.0-rc.48",
     "@zkochan/cmd-shim": "^6.0.0",
-    "better-sqlite3": "^10.0.0",
+    "better-sqlite3": "^11.7.2",
     "clipanion": "patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch",
     "debug": "^4.1.1",
     "esbuild": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/nodejs/corepack.git"
   },
   "engines": {
-    "node": "^18.17.1 || >=20.10.0"
+    "node": "^18.17.1 || ^20.10.0 || >=22.11.0"
   },
   "exports": {
     "./package.json": "./package.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,14 +991,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^10.0.0":
-  version: 10.1.0
-  resolution: "better-sqlite3@npm:10.1.0"
+"better-sqlite3@npm:^11.7.2":
+  version: 11.7.2
+  resolution: "better-sqlite3@npm:11.7.2"
   dependencies:
     bindings: "npm:^1.5.0"
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
-  checksum: 10c0/3c858214b8b6f0c3f536759a863dfc79b11c52cecd6061525fb7707d950ea2ef369280276d8cc62d504119514b7d32ea4aab134d260f6b5a0419a8119d613a67
+  checksum: 10c0/bcc7606dc597738679c073bd7333d44f5abca02b6f87ab1aaf99cf5c3f9d0f29dff39f3cc59de97ff9683fcaeadc8229441396f9d6cca68aa3619672270083c8
   languageName: node
   linkType: hard
 
@@ -1229,7 +1229,7 @@ __metadata:
     "@yarnpkg/eslint-config": "npm:^2.0.0"
     "@yarnpkg/fslib": "npm:^3.0.0-rc.48"
     "@zkochan/cmd-shim": "npm:^6.0.0"
-    better-sqlite3: "npm:^10.0.0"
+    better-sqlite3: "npm:^11.7.2"
     clipanion: "patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch"
     debug: "npm:^4.1.1"
     esbuild: "npm:^0.21.0"


### PR DESCRIPTION
- closes https://github.com/nodejs/corepack/issues/592

## Issue

1. Node.js 21 entered [end-of-life](https://github.com/nodejs/release#release-schedule) on Jun 6, 2024. It is however still allowed by:

https://github.com/nodejs/corepack/blob/0ae3c3c1f5cbbc7fd14b7be8e71e8472215c68d2/package.json#L12-L14

2. The workflow [ci.yml](https://github.com/nodejs/corepack/blob/main/.github/workflows/ci.yml) continues to test it:

https://github.com/nodejs/corepack/blob/0ae3c3c1f5cbbc7fd14b7be8e71e8472215c68d2/.github/workflows/ci.yml#L47-L52

3. There is no version of [better-sqlite3](https://www.npmjs.com/package/better-sqlite3) (used in `devDependencies`) which supports both Node.js 21 and 23, so continuing support for Node.js 21 blocks supporting Node.js 23.

## Change

- Drop support for Node.js 21 in [package.json](https://github.com/nodejs/corepack/blob/main/package.json) `engines` and testing in [ci.yml](https://github.com/nodejs/corepack/blob/main/.github/workflows/ci.yml).
- Update [better-sqlite3](https://www.npmjs.com/package/better-sqlite3) to [better-sqlite3@11.7.2](https://github.com/WiseLibs/better-sqlite3/releases/tag/v11.7.2) (Edit: was `latest` when this PR was originally submitted).

### Additional change
- Add Node.js 23 to workflow and exclude `windows-latest` from testing due to issue #597