### PR TITLE
docs: fix new shims contributing typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ New package managers can be added by editing the following files:
 - [`config.json`](./config.json),
 - [`.github/workflows/sync.yml`](./.github/workflows/sync.yml) that keeps pinned
   versions up-to-date,
-- [`package.json`](./package.json) to add to add the added shims to the list of
+- [`package.json`](./package.json) to add the new shims to the list of
   `"publishConfig/bin"` and `"executableFiles"`,
 - [`sources/types.ts`](./sources/types.ts) to add the package manager to the
   `SupportedPackageManagers` enum,


### PR DESCRIPTION
## Issue

[Adding a new package manager](https://github.com/nodejs/corepack/blob/main/CONTRIBUTING.md#adding-a-new-package-manager) contains text with repeated words / phrases:

> - [`package.json`](https://github.com/nodejs/corepack/blob/main/package.json) to add to add the added shims to the list of
  `"publishConfig/bin"` and `"executableFiles"`,

with add / add / added

## Change to

> - [`package.json`](https://github.com/nodejs/corepack/blob/main/package.json) to add new shims to the list of
  `"publishConfig/bin"` and `"executableFiles"`,