### PR TITLE
docs: add DEBUG=corepack logging instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,7 @@ If you want to build Corepack yourself, you can build the project like this:
 
 The `dist/` directory now contains the corepack build and the shims.
 Call `node ./dist/corepack --help` and behold.
-
-You can also run the tests with `yarn test`. (Do not set the environment variable `DEBUG=corepack` when running tests. The additional debug logging causes tests to fail.)
+You can also run the tests with `yarn test`.
 
 # Adding a new package manager
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ If you want to build Corepack yourself, you can build the project like this:
 
 The `dist/` directory now contains the corepack build and the shims.
 Call `node ./dist/corepack --help` and behold.
-You can also run the tests with `yarn test`.
+
+You can also run the tests with `yarn test`. (Do not set the environment variable `DEBUG=corepack` when running tests. The additional debug logging causes tests to fail.)
 
 # Adding a new package manager
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ same major line. Should you need to upgrade to a new major, use an explicit
 
 ## Troubleshooting
 
+The environment variable `DEBUG` can be set to `corepack` to enable additional debug logging.
+
 ### Networking
 
 There are a wide variety of networking issues that can occur while running


### PR DESCRIPTION
- closes #603

## Change

Add information to the following document~~s~~ regarding use of the npm [debug](https://www.npmjs.com/package/debug) module by setting the related environment variable `DEBUG=corepack` to enable additional debug logging:

- [README](https://github.com/nodejs/corepack/blob/main/README.md) document and
- ~~[CONTRIBUTING](https://github.com/nodejs/corepack/blob/main/CONTRIBUTING.md) document~~ Edit: removed this change