### PR TITLE
docs: add contributor windows os non-homedrive usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 If you want to build Corepack yourself, you can build the project like this:
 
-1. Clone this repository. (See below [Contributing on Windows](#contributing-on-windows) if you plan to use Microsoft Windows.)
+1. Clone this repository. Some restrictions on the cloning location apply to Windows users, read [Contributing on Windows](#contributing-on-windows) for more information.
 2. Run `yarn install` (or `corepack yarn install` if the global version of
    `yarn` is not provided by Corepack).
 3. Run `yarn build` (or `corepack yarn build`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 If you want to build Corepack yourself, you can build the project like this:
 
-1. Clone this repository.
+1. Clone this repository. (See below [Contributing on Windows](#contributing-on-windows) if you plan to use Microsoft Windows.)
 2. Run `yarn install` (or `corepack yarn install` if the global version of
    `yarn` is not provided by Corepack).
 3. Run `yarn build` (or `corepack yarn build`).
@@ -10,6 +10,12 @@ If you want to build Corepack yourself, you can build the project like this:
 The `dist/` directory now contains the corepack build and the shims.
 Call `node ./dist/corepack --help` and behold.
 You can also run the tests with `yarn test`.
+
+## Contributing on Windows
+
+If you are cloning the repo to a directory on a Microsoft Windows operating system, it is recommended to use the same drive as your Windows `HOMEDRIVE` to avoid build and other issues related to a current restriction with Yarn Plug'n'Play caching.
+
+If you are unable to use your `HOMEDRIVE`, you may be able to work around the issue by setting the environment variable `YARN_ENABLE_GLOBAL_CACHE` to `false` before running `yarn install` (or `corepack yarn install`).
 
 # Adding a new package manager
 


### PR DESCRIPTION
- addresses documentation related to #598

## Issue

- As described in issue https://github.com/nodejs/corepack/issues/598, if the instructions in [CONTRIBUTING](https://github.com/nodejs/corepack/blob/main/CONTRIBUTING.md) are followed to clone the repo, install dependencies with Yarn and then build with Yarn, these steps fail if running on a Microsoft Windows operating system and the repo has been cloned to a drive which is not the user's `HOMEDRIVE`.

- Pending the implementation of Yarn feature request https://github.com/yarnpkg/berry/issues/4030, [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) is not compatible with the above Windows configuration.

- The [corepack repo](https://github.com/nodejs/corepack) is currently configured to use [Yarn 4.3.1](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.3.1) and since [nodeLinker](https://yarnpkg.com/configuration/yarnrc#nodeLinker) is unconfigured, it defaults to `nodeLinker: "pnp"` for [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp).

https://github.com/nodejs/corepack/blob/2a04e7c8da26807d36825cb289d5d9d3a0c71669/package.json#L19

## Change

Add a recommendation and workaround instructions to [CONTRIBUTING](https://github.com/nodejs/corepack/blob/main/CONTRIBUTING.md) for contributors working on Microsoft Windows, related to drive usage.