### PR TITLE
chore: update yarn to 4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "license": "MIT",
-  "packageManager": "yarn@4.3.1+sha224.934d21773e22af4b69a7032a2d3b4cb38c1f7c019624777cc9916b23",
+  "packageManager": "yarn@4.6.0+sha512.5383cc12567a95f1d668fbe762dfe0075c595b4bfff433be478dbbe24e05251a8e8c3eb992a986667c1d53b6c3a9c85b8398c35a960587fbd9fa3a0915406728",
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/node": "^20.4.6",


### PR DESCRIPTION
This is a housekeeping PR to update the repo's own `packageManager` record in [package.json](https://github.com/nodejs/corepack/blob/main/package.json) from [yarn@4.3.1](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.3.1) (released Jun 21, 2024) to [yarn@4.6.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.6.0) (current `latest` released Dec 29, 2024) using Corepack's own command

```shell
corepack up
```

It also updates the `packageManager` hash for `yarn` from `sha224` to `sha512`, bringing it in line with the currently used default hash type.