### PR TITLE
docs: add instructions to update corepack

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ is distributed along with Node.js itself.
 
 </details>
 
+<details><summary>Update Corepack using npm</summary>
+
+To install the latest version of Corepack, use:
+
+```shell
+npm install -g corepack@latest
+```
+
+If you are a Windows user and you [downloaded and installed Node.js](https://nodejs.org/en/download) using a Windows Installer `.msi` package then you need to disable the "corepack manager" feature of the Node.js `.msi` package by selecting "Entire feature will be unavailable" before attempting to install a different version of Corepack using npm.
+You can select the Modify option of the Node.js app settings to access the Windows Installer feature selection.
+(See [Repair apps and programs in Windows](https://support.microsoft.com/en-au/windows/repair-apps-and-programs-in-windows-e90eefe4-d0a2-7c1b-dd59-949a9030f317) for instructions on accessing the Windows apps page to modify settings.)
+
+</details>
+
 <details><summary>Install Corepack from source</summary>
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ To install the latest version of Corepack, use:
 npm install -g corepack@latest
 ```
 
-If you are a Windows user and you [downloaded and installed Node.js](https://nodejs.org/en/download) using a Windows Installer `.msi` package then you need to disable the "corepack manager" feature of the Node.js `.msi` package by selecting "Entire feature will be unavailable" before attempting to install a different version of Corepack using npm.
-You can select the Modify option of the Node.js app settings to access the Windows Installer feature selection.
-(See [Repair apps and programs in Windows](https://support.microsoft.com/en-us/windows/repair-apps-and-programs-in-windows-e90eefe4-d0a2-7c1b-dd59-949a9030f317) for instructions on accessing the Windows apps page to modify settings.)
+If Corepack was installed on your system using a Node.js Windows Installer
+`.msi` package then you might need to remove it before attempting to install a
+different version of Corepack using npm. You can select the Modify option of the
+Node.js app settings to access the Windows Installer feature selection, and on
+the "corepack manager" feature of the Node.js `.msi` package by selecting
+"Entire feature will be unavailable". See
+[Repair apps and programs in Windows](https://support.microsoft.com/en-us/windows/repair-apps-and-programs-in-windows-e90eefe4-d0a2-7c1b-dd59-949a9030f317)
+for instructions on accessing the Windows apps page to modify settings.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm install -g corepack@latest
 
 If you are a Windows user and you [downloaded and installed Node.js](https://nodejs.org/en/download) using a Windows Installer `.msi` package then you need to disable the "corepack manager" feature of the Node.js `.msi` package by selecting "Entire feature will be unavailable" before attempting to install a different version of Corepack using npm.
 You can select the Modify option of the Node.js app settings to access the Windows Installer feature selection.
-(See [Repair apps and programs in Windows](https://support.microsoft.com/en-au/windows/repair-apps-and-programs-in-windows-e90eefe4-d0a2-7c1b-dd59-949a9030f317) for instructions on accessing the Windows apps page to modify settings.)
+(See [Repair apps and programs in Windows](https://support.microsoft.com/en-us/windows/repair-apps-and-programs-in-windows-e90eefe4-d0a2-7c1b-dd59-949a9030f317) for instructions on accessing the Windows apps page to modify settings.)
 
 </details>
 


### PR DESCRIPTION
- relates to #305

## Change

Add a sub-section "Update Corepack using npm" to the [README](https://github.com/nodejs/corepack/blob/main/README.md) document, [Manual installs](https://github.com/nodejs/corepack/blob/main/README.md#manual-installs) section.

It covers a regular update with `npm install -g corepack@latest` and describes how to update Corepack if Node.js has been installed on Windows using a Windows Installer `.msi` package, which requires disabling the "corepack manager" feature before attempting a Corepack update.