### PR TITLE
feat: add support for `.corepack.env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ same major line. Should you need to upgrade to a new major, use an explicit
 
 - `COREPACK_ENV_FILE` can be set to `0` to request Corepack to not attempt to
   load `.corepack.env`; it can be set to a path to specify a different env file.
-  Only keys that starts with `COREPACK_` will be taken into account, not all
+  Only keys that start with `COREPACK_` will be taken into account, not all
   keys that start with `COREPACK_` will be taken into account (
   `COREPACK_ENABLE_DOWNLOAD_PROMPT` and `COREPACK_ENV_FILE` are ignored).
   For Node.js 18.x users, this setting has no effect as that version doesn't

--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ same major line. Should you need to upgrade to a new major, use an explicit
 
 - `COREPACK_ENV_FILE` can be set to `0` to request Corepack to not attempt to
   load `.corepack.env`; it can be set to a path to specify a different env file.
-  Only keys that start with `COREPACK_` will be taken into account, not all
-  keys that start with `COREPACK_` will be taken into account (
-  `COREPACK_ENABLE_DOWNLOAD_PROMPT` and `COREPACK_ENV_FILE` are ignored).
+  Only keys that start with `COREPACK_` and are not in the exception list
+  (`COREPACK_ENABLE_DOWNLOAD_PROMPT` and `COREPACK_ENV_FILE` are ignored)
+  will be taken into account.
   For Node.js 18.x users, this setting has no effect as that version doesn't
   support parsing of `.env` files.
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ same major line. Should you need to upgrade to a new major, use an explicit
   set to `1` to have the URL shown. By default, when Corepack is called
   explicitly (e.g. `corepack pnpm …`), it is set to `0`; when Corepack is called
   implicitly (e.g. `pnpm …`), it is set to `1`.
+  The default value cannot be overridden in a `.corepack.env` file.
   When standard input is a TTY and no CI environment is detected, Corepack will
   ask for user input before starting the download.
 
@@ -291,6 +292,14 @@ same major line. Should you need to upgrade to a new major, use an explicit
   checking if the package manager corresponds to the one defined for the current
   project. This means that it will always use the system-wide package manager
   regardless of what is being specified in the project's `packageManager` field.
+
+- `COREPACK_ENV_FILE` can be set to `0` to request Corepack to not attempt to
+  load `.corepack.env`; it can be set to a path to specify a different env file.
+  Only keys that starts with `COREPACK_` will be taken into account, not all
+  keys that start with `COREPACK_` will be taken into account (
+  `COREPACK_ENABLE_DOWNLOAD_PROMPT` and `COREPACK_ENV_FILE` are ignored).
+  For Node.js 18.x users, this setting has no effect as that version doesn't
+  support parsing of `.env` files.
 
 - `COREPACK_HOME` can be set in order to define where Corepack should install
   the package managers. By default it is set to `%LOCALAPPDATA%\node\corepack`

--- a/sources/npmRegistryUtils.ts
+++ b/sources/npmRegistryUtils.ts
@@ -38,6 +38,8 @@ export function verifySignature({signatures, integrity, packageName, version}: {
   packageName: string;
   version: string;
 }) {
+  if (signatures == null) throw new Error(`No compatible signature found in package metadata for ${packageName}@${version}`);
+
   const {npm: keys} = process.env.COREPACK_INTEGRITY_KEYS ?
     JSON.parse(process.env.COREPACK_INTEGRITY_KEYS) as typeof defaultConfig.keys :
     defaultConfig.keys;

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -121,6 +121,10 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
     if (process.env.COREPACK_ENV_FILE == `0`) {
       debugUtils.log(`Skipping env file as configured with COREPACK_ENV_FILE`);
       localEnv = process.env;
+    } else if (typeof parseEnv !== `function`) {
+      // TODO: remove this block when support for Node.js 18.x is dropped.
+      debugUtils.log(`Skipping env file as it is not supported by the current version of Node.js`);
+      localEnv = process.env;
     } else {
       debugUtils.log(`Checking ${envFilePath}`);
       try {

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -4,6 +4,7 @@ import path                                    from 'path';
 import semverSatisfies                         from 'semver/functions/satisfies';
 import semverValid                             from 'semver/functions/valid';
 import semverValidRange                        from 'semver/ranges/valid';
+import {parseEnv}                              from 'util';
 
 import {PreparedPackageManagerInfo}            from './Engine';
 import * as debugUtils                         from './debugUtils';
@@ -146,7 +147,13 @@ export async function setLocalPackageManager(cwd: string, info: PreparedPackageM
   };
 }
 
-type FoundSpecResult = {type: `Found`, target: string, getSpec: () => Descriptor, range?: Descriptor, envFilePath?: string} & {onFail?: DevEngineDependency['onFail']}};
+interface FoundSpecResult {
+  type: `Found`;
+  target: string;
+  getSpec: () => Descriptor;
+  range?: Descriptor & {onFail?: DevEngineDependency['onFail']};
+  envFilePath?: string;
+}
 export type LoadSpecResult =
     | {type: `NoProject`, target: string}
     | {type: `NoSpec`, target: string}

--- a/sources/types.ts
+++ b/sources/types.ts
@@ -160,3 +160,5 @@ export interface LazyLocator {
      */
   reference: () => Promise<string>;
 }
+
+export type LocalEnvFile = Record<string, string | undefined>;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -318,7 +318,7 @@ for (const name of SupportedPackageManagerSet) {
   });
 }
 
-describe.only(`when called on a project without any defined packageManager`, () => {
+describe(`when called on a project without any defined packageManager`, () => {
   it(`should append the field to package.json by default`, async () => {
     await xfs.mktempPromise(async cwd => {
       await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -932,7 +932,10 @@ describe(`should pick up COREPACK_INTEGRITY_KEYS from env`, () => {
     });
   });
 
-  it(`from .corepack.env file`, async () => {
+  it(`from .corepack.env file`, async t => {
+    // Skip that test on Node.js 18.x as it lacks support for .env files.
+    if (process.version.startsWith(`v18.`)) t.skip();
+
     await xfs.mktempPromise(async cwd => {
       await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
       });
@@ -952,7 +955,10 @@ describe(`should pick up COREPACK_INTEGRITY_KEYS from env`, () => {
     });
   });
 
-  it(`from env file defined by COREPACK_ENV_FILE`, async () => {
+  it(`from env file defined by COREPACK_ENV_FILE`, async t => {
+    // Skip that test on Node.js 18.x as it lacks support for .env files.
+    if (process.version.startsWith(`v18.`)) t.skip();
+
     await xfs.mktempPromise(async cwd => {
       await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
       });
@@ -983,7 +989,7 @@ describe(`should pick up COREPACK_INTEGRITY_KEYS from env`, () => {
 
       await xfs.writeFilePromise(ppath.join(cwd, `.corepack.env` as Filename), `COREPACK_INTEGRITY_KEYS={}\n`);
 
-      // By default, Corepack should be using .corepack.env and fail.
+      // By default, Corepack should be using .corepack.env (or the built-in ones on Node.js 18.x) and fail.
       await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
         stdout: ``,
@@ -999,7 +1005,10 @@ describe(`should pick up COREPACK_INTEGRITY_KEYS from env`, () => {
     });
   });
 
-  it(`should ignore .corepack.env file if COREPACK_ENV_FILE is set to 0`, async () => {
+  it(`should ignore .corepack.env file if COREPACK_ENV_FILE is set to 0`, async t => {
+    // Skip that test on Node.js 18.x as it lacks support for .env files.
+    if (process.version.startsWith(`v18.`)) t.skip();
+
     await xfs.mktempPromise(async cwd => {
       await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
       });
@@ -1022,7 +1031,10 @@ describe(`should pick up COREPACK_INTEGRITY_KEYS from env`, () => {
     });
   });
 
-  it(`from env file defined by COREPACK_ENV_FILE`, async () => {
+  it(`from env file defined by COREPACK_ENV_FILE`, async t => {
+    // Skip that test on Node.js 18.x as it lacks support for .env files.
+    if (process.version.startsWith(`v18.`)) t.skip();
+
     process.env.COREPACK_ENV_FILE = `.other.env`;
     await xfs.mktempPromise(async cwd => {
       await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {


### PR DESCRIPTION
This would allow project author to customize the behavior of Corepack – with the recent incident related to npm registry key rotation, it show how it would be useful to override the built-in values. It could also be used to disable auto pinning at a project level.

It's also a first step towards allowing specifying ranges in the `package.json` (see #634), which has been requested for a long long time (https://github.com/nodejs/corepack/issues/95).

Fixes: https://github.com/nodejs/corepack/issues/628