### PR TITLE
feat: add limited support for `devEngines`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ use in the archive).
 }
 ```
 
+#### `devEngines.packageManager`
+
+When a `devEngines.packageManager` field is defined, and is an object containing
+a `"name"` field (can also optionally contain `version` and `onFail` fields),
+Corepack will use it to validate you're using a compatible package manager.
+
+Depending on the value of `devEngines.packageManager.onFail`:
+
+- if set to `ignore`, Corepack won't print any warning or error.
+- if unset or set to `error`, Corepack will throw an error in case of a mismatch.
+- if set to `warn` or some other value, Corepack will print a warning in case
+  of mismatch.
+
 ## Known Good Releases
 
 When running Corepack within projects that don't list a supported package
@@ -246,6 +259,7 @@ it.
 
 Unlike `corepack use` this command doesn't take a package manager name nor a
 version range, as it will always select the latest available version from the
+range specified in `devEngines.packageManager.version`, or fallback to the
 same major line. Should you need to upgrade to a new major, use an explicit
 `corepack use {name}@latest` call (or simply `corepack use {name}`).
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ Depending on the value of `devEngines.packageManager.onFail`:
 - if set to `warn` or some other value, Corepack will print a warning in case
   of mismatch.
 
+If the top-level `packageManager` field is missing, Corepack will use the
+package manager defined in `devEngines.packageManager` – in which case you must
+provide a specific version in `devEngines.packageManager.version`, ideally with
+a hash, as explained in the previous section:
+
+```json
+{
+  "devEngines":{
+    "packageManager": {
+      "name": "yarn",
+      "version": "3.2.3+sha224.953c8233f7a92884eee2de69a1b92d1f2ec1655e66d08071ba9a02fa"
+    }
+  }
+}
+```
+
 ## Known Good Releases
 
 When running Corepack within projects that don't list a supported package

--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -16,7 +16,7 @@ export abstract class BaseCommand extends Command<Context> {
           throw new UsageError(`Couldn't find a project in the local directory - please explicit the package manager to pack, or run this command from a valid project`);
 
         case `NoSpec`:
-          throw new UsageError(`The local project doesn't feature a 'packageManager' field nor a 'devEngines.packageManager' field - please explicit the package manager to pack, or update the manifest to reference it`);
+          throw new UsageError(`The local project doesn't feature a 'packageManager' field nor a 'devEngines.packageManager' field - please specify the package manager to pack, or update the manifest to reference it`);
 
         default: {
           return [lookup.range ?? lookup.spec];

--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -19,7 +19,7 @@ export abstract class BaseCommand extends Command<Context> {
           throw new UsageError(`The local project doesn't feature a 'packageManager' field - please explicit the package manager to pack, or update the manifest to reference it`);
 
         default: {
-          return [lookup.spec];
+          return [lookup.range ?? lookup.spec];
         }
       }
     }

--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -16,7 +16,7 @@ export abstract class BaseCommand extends Command<Context> {
           throw new UsageError(`Couldn't find a project in the local directory - please explicit the package manager to pack, or run this command from a valid project`);
 
         case `NoSpec`:
-          throw new UsageError(`The local project doesn't feature a 'packageManager' field - please explicit the package manager to pack, or update the manifest to reference it`);
+          throw new UsageError(`The local project doesn't feature a 'packageManager' field nor a 'devEngines.packageManager' field - please explicit the package manager to pack, or update the manifest to reference it`);
 
         default: {
           return [lookup.range ?? lookup.spec];

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -66,14 +66,16 @@ function parsePackageJSON(packageJSONContent: CorepackPackageJSON) {
   if (packageJSONContent.devEngines?.packageManager) {
     const {packageManager} = packageJSONContent.devEngines;
 
-    if (Array.isArray(packageManager))
-      throw new UsageError(`Providing several package managers is currently not supported`);
+    if (Array.isArray(packageManager)) {
+      console.warn(`! Corepack does not currently supported array values for devEngines.packageManager`);
+      return packageJSONContent.packageManager;
+    }
 
     const {version} = packageManager;
     if (!version)
       throw new UsageError(`Package manager version or version range is required`);
 
-    debugUtils.log(`devEngines defines that ${packageManager.name}@${version} is the local package manager`);
+    debugUtils.log(`devEngines.packageManager defines that ${packageManager.name}@${version} is the local package manager`);
 
     const {packageManager: pm} = packageJSONContent;
     if (pm) {

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -196,7 +196,6 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
 
   debugUtils.log(`${selection.manifestPath} defines ${rawPmSpec} as local package manager`);
 
-  const spec = parseSpec(rawPmSpec, path.relative(initialCwd, selection.manifestPath));
   return {
     type: `Found`,
     target: selection.manifestPath,

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -71,7 +71,7 @@ function parsePackageJSON(packageJSONContent: CorepackPackageJSON) {
 
     const {version} = packageManager;
     if (!version)
-      throw new UsageError(`Providing no version nor ranger for package manager is currently not supported`);
+      throw new UsageError(`Package manager version or version range is required`);
 
     debugUtils.log(`devEngines defines that ${packageManager.name}@${version} is the local package manager`);
 

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -76,33 +76,33 @@ function warnOrThrow(errorMessage: string, onFail?: DevEngineDependency['onFail'
   }
 }
 function parsePackageJSON(packageJSONContent: CorepackPackageJSON) {
+  const {packageManager: pm} = packageJSONContent;
   if (packageJSONContent.devEngines?.packageManager != null) {
     const {packageManager} = packageJSONContent.devEngines;
 
     if (typeof packageManager !== `object`) {
       console.warn(`! Corepack only supports objects as valid value for devEngines.packageManager. The current value (${JSON.stringify(packageManager)}) will be ignored.`);
-      return packageJSONContent.packageManager;
+      return pm;
     }
     if (Array.isArray(packageManager)) {
       console.warn(`! Corepack does not currently support array values for devEngines.packageManager`);
-      return packageJSONContent.packageManager;
+      return pm;
     }
 
     const {name, version, onFail} = packageManager;
     if (typeof name !== `string` || name.includes(`@`)) {
       warnOrThrow(`The value of devEngines.packageManager.name ${JSON.stringify(name)} is not a supported string value`, onFail);
-      return packageJSONContent.packageManager;
+      return pm;
     }
     if (version != null && (typeof version !== `string` || !semverValidRange(version))) {
       warnOrThrow(`The value of devEngines.packageManager.version ${JSON.stringify(version)} is not a valid semver range`, onFail);
-      return packageJSONContent.packageManager;
+      return pm;
     }
 
     debugUtils.log(`devEngines.packageManager defines that ${name}@${version} is the local package manager`);
 
-    const {packageManager: pm} = packageJSONContent;
     if (pm) {
-      if (!pm.startsWith(`${name}@`))
+      if (!pm.startsWith?.(`${name}@`))
         warnOrThrow(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the "devEngines.packageManager" field set to ${JSON.stringify(name)}`, onFail);
 
       else if (version != null && !semverSatisfies(pm.slice(packageManager.name.length + 1), version))
@@ -115,7 +115,7 @@ function parsePackageJSON(packageJSONContent: CorepackPackageJSON) {
     return `${name}@${version ?? `*`}`;
   }
 
-  return packageJSONContent.packageManager;
+  return pm;
 }
 
 export async function setLocalPackageManager(cwd: string, info: PreparedPackageManagerInfo) {

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -1,6 +1,7 @@
 import {UsageError}                            from 'clipanion';
 import fs                                      from 'fs';
 import path                                    from 'path';
+import semverSatisfies                         from 'semver/functions/satisfies';
 import semverValid                             from 'semver/functions/valid';
 
 import {PreparedPackageManagerInfo}            from './Engine';
@@ -52,6 +53,46 @@ export function parseSpec(raw: unknown, source: string, {enforceExactVersion = t
   };
 }
 
+type CorepackPackageJSON = {
+  packageManager?: string;
+  devEngines?: { packageManager?: DevEngineDependency };
+};
+
+interface DevEngineDependency {
+  name: string;
+  version: string;
+}
+function parsePackageJSON(packageJSONContent: CorepackPackageJSON) {
+  if (packageJSONContent.devEngines?.packageManager) {
+    const {packageManager} = packageJSONContent.devEngines;
+
+    if (Array.isArray(packageManager))
+      throw new UsageError(`Providing several package managers is currently not supported`);
+
+    const {version} = packageManager;
+    if (!version)
+      throw new UsageError(`Providing no version nor ranger for package manager is currently not supported`);
+
+    debugUtils.log(`devEngines defines that ${packageManager.name}@${version} is the local package manager`);
+
+    const {packageManager: pm} = packageJSONContent;
+    if (pm) {
+      if (!pm.startsWith(`${packageManager.name}@`))
+        throw new UsageError(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the "devEngines.packageManager" field set to ${JSON.stringify(packageManager.name)}`);
+
+      if (!semverSatisfies(pm.slice(packageManager.name.length + 1), version))
+        throw new UsageError(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the value defined in "devEngines.packageManager" for ${JSON.stringify(packageManager.name)} of ${JSON.stringify(version)}`);
+
+      return pm;
+    }
+
+
+    return `${packageManager.name}@${version}`;
+  }
+
+  return packageJSONContent.packageManager;
+}
+
 export async function setLocalPackageManager(cwd: string, info: PreparedPackageManagerInfo) {
   const lookup = await loadSpec(cwd);
 
@@ -75,7 +116,7 @@ export async function setLocalPackageManager(cwd: string, info: PreparedPackageM
 export type LoadSpecResult =
     | {type: `NoProject`, target: string}
     | {type: `NoSpec`, target: string}
-    | {type: `Found`, target: string, spec: Descriptor};
+    | {type: `Found`, target: string, spec: Descriptor, range?: Descriptor};
 
 export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
   let nextCwd = initialCwd;
@@ -117,13 +158,17 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
   if (selection === null)
     return {type: `NoProject`, target: path.join(initialCwd, `package.json`)};
 
-  const rawPmSpec = selection.data.packageManager;
+  const rawPmSpec = parsePackageJSON(selection.data);
   if (typeof rawPmSpec === `undefined`)
     return {type: `NoSpec`, target: selection.manifestPath};
 
+  debugUtils.log(`${selection.manifestPath} defines ${rawPmSpec} as local package manager`);
+
+  const spec = parseSpec(rawPmSpec, path.relative(initialCwd, selection.manifestPath));
   return {
     type: `Found`,
     target: selection.manifestPath,
-    spec: parseSpec(rawPmSpec, path.relative(initialCwd, selection.manifestPath)),
+    spec,
+    range: selection.data.devEngines?.packageManager?.version && {...spec, range: selection.data.devEngines.packageManager.version},
   };
 }

--- a/tests/Up.test.ts
+++ b/tests/Up.test.ts
@@ -27,7 +27,7 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
-          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n/),
         });
 
         await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
@@ -57,7 +57,7 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
-          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n/),
         });
 
         await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
@@ -88,7 +88,7 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
-          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n/),
         });
 
         await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
@@ -118,7 +118,7 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
-          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n/),
         });
 
         await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({

--- a/tests/Up.test.ts
+++ b/tests/Up.test.ts
@@ -21,6 +21,7 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
         });
 
         await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
@@ -30,6 +31,7 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
           exitCode: 0,
           stdout: `2.4.3\n`,
+          stderr: ``,
         });
       });
     });
@@ -49,6 +51,7 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
         });
 
         await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
@@ -58,6 +61,7 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
           exitCode: 0,
           stdout: `2.4.3\n`,
+          stderr: ``,
         });
       });
     });
@@ -78,6 +82,7 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
         });
 
         await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
@@ -87,6 +92,27 @@ describe(`UpCommand`, () => {
         await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
           exitCode: 0,
           stdout: `2.4.3\n`,
+          stderr: ``,
+        });
+      });
+    });
+
+    it(`should fail if no top-level 'packageManager' field`, async () => {
+      await xfs.mktempPromise(async cwd => {
+        process.env.NO_COLOR = `1`;
+        await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
+          devEngines: {
+            packageManager: {
+              name: `yarn`,
+              version: `1.x || 2.x`,
+            },
+          },
+        });
+
+        await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
+          exitCode: 1,
+          stderr: ``,
+          stdout: `Usage Error: Invalid package manager specification in package.json (yarn@1.x || 2.x); expected a semver version\n\n$ corepack up\n`,
         });
       });
     });

--- a/tests/Up.test.ts
+++ b/tests/Up.test.ts
@@ -11,24 +11,54 @@ beforeEach(async () => {
 });
 
 describe(`UpCommand`, () => {
-  it(`should upgrade the package manager from the current project`, async () => {
-    await xfs.mktempPromise(async cwd => {
-      await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
-        packageManager: `yarn@2.1.0`,
-      });
+  describe(`should update the "packageManager" field from the current project`, () => {
+    it(`to the same major if no devEngines range`, async () => {
+      await xfs.mktempPromise(async cwd => {
+        await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
+          packageManager: `yarn@2.1.0`,
+        });
 
-      await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
-        exitCode: 0,
-        stderr: ``,
-      });
+        await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
+          exitCode: 0,
+          stderr: ``,
+        });
 
-      await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
-        packageManager: `yarn@2.4.3+sha512.8dd9fedc5451829619e526c56f42609ad88ae4776d9d3f9456d578ac085115c0c2f0fb02bb7d57fd2e1b6e1ac96efba35e80a20a056668f61c96934f67694fd0`,
-      });
+        await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
+          packageManager: `yarn@2.4.3+sha512.8dd9fedc5451829619e526c56f42609ad88ae4776d9d3f9456d578ac085115c0c2f0fb02bb7d57fd2e1b6e1ac96efba35e80a20a056668f61c96934f67694fd0`,
+        });
 
-      await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
-        exitCode: 0,
-        stdout: `2.4.3\n`,
+        await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: `2.4.3\n`,
+        });
+      });
+    });
+
+    it(`to whichever range devEngines defines`, async () => {
+      await xfs.mktempPromise(async cwd => {
+        await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
+          packageManager: `yarn@1.1.0`,
+          devEngines: {
+            packageManager: {
+              name: `yarn`,
+              version: `1.x || 2.x`,
+            },
+          },
+        });
+
+        await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
+          exitCode: 0,
+          stderr: ``,
+        });
+
+        await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
+          packageManager: `yarn@2.4.3+sha512.8dd9fedc5451829619e526c56f42609ad88ae4776d9d3f9456d578ac085115c0c2f0fb02bb7d57fd2e1b6e1ac96efba35e80a20a056668f61c96934f67694fd0`,
+        });
+
+        await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: `2.4.3\n`,
+        });
       });
     });
   });

--- a/tests/Up.test.ts
+++ b/tests/Up.test.ts
@@ -61,5 +61,34 @@ describe(`UpCommand`, () => {
         });
       });
     });
+
+    it(`to whichever range devEngines defines even if onFail is set to ignore`, async () => {
+      await xfs.mktempPromise(async cwd => {
+        await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
+          packageManager: `pnpm@10.1.0`,
+          devEngines: {
+            packageManager: {
+              name: `yarn`,
+              version: `1.x || 2.x`,
+              onFail: `ignore`,
+            },
+          },
+        });
+
+        await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
+          exitCode: 0,
+          stderr: ``,
+        });
+
+        await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
+          packageManager: `yarn@2.4.3+sha512.8dd9fedc5451829619e526c56f42609ad88ae4776d9d3f9456d578ac085115c0c2f0fb02bb7d57fd2e1b6e1ac96efba35e80a20a056668f61c96934f67694fd0`,
+        });
+
+        await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: `2.4.3\n`,
+        });
+      });
+    });
   });
 });

--- a/tests/Up.test.ts
+++ b/tests/Up.test.ts
@@ -103,7 +103,7 @@ describe(`UpCommand`, () => {
       });
     });
 
-    it(`should fail if no top-level 'packageManager' field`, async () => {
+    it(`should succeed even if no 'packageManager' field`, async () => {
       await xfs.mktempPromise(async cwd => {
         process.env.NO_COLOR = `1`;
         await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
@@ -116,9 +116,19 @@ describe(`UpCommand`, () => {
         });
 
         await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
-          exitCode: 1,
+          exitCode: 0,
           stderr: ``,
-          stdout: `Usage Error: Invalid package manager specification in package.json (yarn@1.x || 2.x); expected a semver version\n\n$ corepack up\n`,
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
+        });
+
+        await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
+          packageManager: `yarn@2.4.3+sha512.8dd9fedc5451829619e526c56f42609ad88ae4776d9d3f9456d578ac085115c0c2f0fb02bb7d57fd2e1b6e1ac96efba35e80a20a056668f61c96934f67694fd0`,
+        });
+
+        await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: `2.4.3\n`,
+          stderr: ``,
         });
       });
     });

--- a/tests/Use.test.ts
+++ b/tests/Use.test.ts
@@ -11,23 +11,100 @@ beforeEach(async () => {
 });
 
 describe(`UseCommand`, () => {
-  it(`should set the package manager in the current project`, async () => {
-    await xfs.mktempPromise(async cwd => {
-      await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
-        packageManager: `yarn@1.0.0`,
-      });
+  describe(`should set the package manager in the current project`, () => {
+    it(`With an existing 'packageManager' field`, async () => {
+      await xfs.mktempPromise(async cwd => {
+        await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
+          packageManager: `yarn@1.0.0`,
+          license: `MIT`,
+        });
 
-      await expect(runCli(cwd, [`use`, `yarn@1.22.4`])).resolves.toMatchObject({
-        exitCode: 0,
-      });
+        await expect(runCli(cwd, [`use`, `yarn@1.22.4`])).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\n(.*\n)+Done in \d+\.\d+s\.\n$/),
+          stderr: ``,
+        });
 
-      await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
-        packageManager: `yarn@1.22.4+sha512.a1833b862fe52169bd6c2a033045a07df5bc6a23595c259e675fed1b2d035ab37abe6ce309720abb6636d68f03615054b6292dc0a70da31c8697fda228b50d18`,
-      });
+        await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
+          packageManager: `yarn@1.22.4+sha512.a1833b862fe52169bd6c2a033045a07df5bc6a23595c259e675fed1b2d035ab37abe6ce309720abb6636d68f03615054b6292dc0a70da31c8697fda228b50d18`,
+        });
 
-      await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
-        exitCode: 0,
-        stdout: `1.22.4\n`,
+        await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: `1.22.4\n`,
+          stderr: ``,
+        });
+      });
+    });
+    it(`with 'devEngines.packageManager' field`, async () => {
+      await xfs.mktempPromise(async cwd => {
+        process.env.NO_COLOR = `1`;
+        const devEngines = {packageManager: {name: `yarn`, version: `2.x`}};
+        await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
+          devEngines,
+        });
+
+        // Should refuse to install an incompatible version:
+        await expect(runCli(cwd, [`use`, `yarn@1.22.4`])).resolves.toMatchObject({
+          exitCode: 1,
+          stderr: ``,
+          stdout: `Installing yarn@1.22.4 in the project...\nUsage Error: The requested version of yarn@1.22.4+sha512.a1833b862fe52169bd6c2a033045a07df5bc6a23595c259e675fed1b2d035ab37abe6ce309720abb6636d68f03615054b6292dc0a70da31c8697fda228b50d18 does not match the devEngines specification (yarn@2.x)\n\n$ corepack use <pattern>\n`,
+        });
+
+        // Should accept setting to a compatible version:
+        await expect(runCli(cwd, [`use`, `yarn@2.4.3`])).resolves.toMatchObject({
+          exitCode: 0,
+          stderr: ``,
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
+        });
+
+        await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
+          devEngines,
+          packageManager: `yarn@2.4.3+sha512.8dd9fedc5451829619e526c56f42609ad88ae4776d9d3f9456d578ac085115c0c2f0fb02bb7d57fd2e1b6e1ac96efba35e80a20a056668f61c96934f67694fd0`,
+        });
+
+        await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: `2.4.3\n`,
+          stderr: ``,
+        });
+      });
+    });
+
+    it(`with 'devEngines.packageManager' and 'packageManager' fields`, async () => {
+      await xfs.mktempPromise(async cwd => {
+        process.env.NO_COLOR = `1`;
+        const devEngines = {packageManager: {name: `yarn`, version: `1.x || 2.x`}};
+        await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
+          devEngines,
+          packageManager: `yarn@1.1.0`,
+          license: `MIT`,
+        });
+
+        // Should refuse to install an incompatible version:
+        await expect(runCli(cwd, [`use`, `yarn@1.22.4`])).resolves.toMatchObject({
+          exitCode: 0,
+          stderr: ``,
+          stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\n(.*\n)+Done in \d+\.\d+s\.\n$/),
+        });
+
+        // Should accept setting to a compatible version:
+        await expect(runCli(cwd, [`use`, `yarn@2.4.3`])).resolves.toMatchObject({
+          exitCode: 0,
+          stderr: ``,
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done with warnings in \d+s \d+ms\n$/),
+        });
+
+        await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
+          devEngines,
+          packageManager: `yarn@2.4.3+sha512.8dd9fedc5451829619e526c56f42609ad88ae4776d9d3f9456d578ac085115c0c2f0fb02bb7d57fd2e1b6e1ac96efba35e80a20a056668f61c96934f67694fd0`,
+        });
+
+        await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: `2.4.3\n`,
+          stderr: ``,
+        });
       });
     });
   });

--- a/tests/Use.test.ts
+++ b/tests/Use.test.ts
@@ -27,7 +27,7 @@ describe(`UseCommand`, () => {
 
         await expect(runCli(cwd, [`use`, `yarn@1.22.4`])).resolves.toMatchObject({
           exitCode: 0,
-          stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\n(.*\n)+Done in \d+\.\d+s\.\n$/),
+          stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\n/),
           stderr: ``,
         });
 
@@ -61,7 +61,7 @@ describe(`UseCommand`, () => {
         await expect(runCli(cwd, [`use`, `yarn@2.4.3`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
-          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n/),
         });
 
         await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
@@ -91,14 +91,14 @@ describe(`UseCommand`, () => {
         await expect(runCli(cwd, [`use`, `yarn@1.22.4`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
-          stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\n(.*\n)+Done in \d+\.\d+s\.\n$/),
+          stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\n/),
         });
 
         // Should accept setting to a compatible version:
         await expect(runCli(cwd, [`use`, `yarn@2.4.3`])).resolves.toMatchObject({
           exitCode: 0,
           stderr: ``,
-          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n(.*\n)+➤ YN0000: Done with warnings in \d+s \d+ms\n$/),
+          stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n/),
         });
 
         await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({
@@ -177,7 +177,7 @@ describe(`UseCommand`, () => {
           await expect(runCli(cwd, [`use`, `yarn@1.22.4`])).resolves.toMatchObject({
             exitCode: 0,
             stderr: ``,
-            stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\nyarn install v1\.22\.4\ninfo No lockfile found\.\n(.*\n)+Done in \d+\.\d+s\.\n$/),
+            stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\n/),
           });
 
           await expect(xfs.readJsonPromise(ppath.join(cwd, `package.json`))).resolves.toMatchObject({

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -275,7 +275,7 @@ describe(`should handle invalid devEngines values`, () => {
 
       await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
         exitCode: 1,
-        stderr: expect.stringContaining(`Version or version range is required in packageManager.devEngines.version`),
+        stderr: `Invalid package manager specification in package.json (yarn@*); expected a semver version\n`,
         stdout: ``,
       });
     });
@@ -293,7 +293,7 @@ describe(`should handle invalid devEngines values`, () => {
 
       await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
         exitCode: 1,
-        stderr: expect.stringContaining(`Version or version range is required in packageManager.devEngines.version`),
+        stderr: `The value of devEngines.packageManager.version "yarn@1.x" is not a valid semver range\n`,
         stdout: ``,
       });
     });
@@ -393,6 +393,21 @@ describe(`should accept range in devEngines only if a specific version is provid
           packageManager: {
             name: `pnpm`,
             version: `6.x`,
+          },
+        },
+        packageManager: `pnpm@6.6.2+sha224.eb5c0acad3b0f40ecdaa2db9aa5a73134ad256e17e22d1419a2ab073`,
+      });
+      await expect(runCli(cwd, [`pnpm`, `--version`])).resolves.toMatchObject({
+        exitCode: 0,
+        stderr: ``,
+        stdout: `6.6.2\n`,
+      });
+
+      // No version should also work
+      await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as PortablePath), {
+        devEngines: {
+          packageManager: {
+            name: `pnpm`,
           },
         },
         packageManager: `pnpm@6.6.2+sha224.eb5c0acad3b0f40ecdaa2db9aa5a73134ad256e17e22d1419a2ab073`,

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -172,7 +172,11 @@ for (const [name, version, expectedVersion = version.split(`+`, 1)[0]] of tested
         devEngines: {packageManager: {name, version}},
       });
 
-      await expect(runCli(cwd, [name, `--version`])).resolves.toMatchObject({
+      await expect(runCli(cwd, [name, `--version`])).resolves.toMatchObject(URL.canParse(version) ? {
+        exitCode: 1,
+        stderr: `Version or version range is required in packageManager.devEngines.version\n`,
+        stdout: ``,
+      } : {
         exitCode: 0,
         stderr: ``,
         stdout: `${expectedVersion}\n`,


### PR DESCRIPTION
This implementation of `devEngines` support in this PR is limited to `packageManager` only, only one `packageManager` can be specified, ~the `onFail` field is ignored~ EDIT: I've added support for the `onFail` field, supporting the same values as npm.

Fixes: https://github.com/nodejs/corepack/issues/567