### PR TITLE
Make e2e test faster, don’t keep http connections alive

### DIFF
--- a/tests/_registryServer.mjs
+++ b/tests/_registryServer.mjs
@@ -111,6 +111,8 @@ function generateVersionMetadata(packageName, version) {
 const TOKEN_MOCK = `SOME_DUMMY_VALUE`;
 
 const server = createServer((req, res) => {
+  res.setHeader(`connection`, `close`);
+
   const auth = req.headers.authorization;
 
   if (


### PR DESCRIPTION
This change almost halves the time it takes to run `tests/main.test.ts` from 150s to 70s.