### PR TITLE
Fix or mark false-positives in end-to-end tests

### DIFF
--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -24,7 +24,7 @@ it(`should refuse to download a package manager if the hash doesn't match`, asyn
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: /Mismatch hashes/,
+      stderr: expect.stringContaining(`Mismatch hashes`),
       stdout: ``,
     });
   });
@@ -35,7 +35,7 @@ it(`should refuse to download a known package manager from a URL`, async () => {
     // Package managers known by Corepack cannot be loaded from a URL.
     await expect(runCli(cwd, [`yarn@https://registry.npmjs.com/yarn/-/yarn-1.22.21.tgz`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: /Illegal use of URL for known package manager/,
+      stderr: expect.stringContaining(`Illegal use of URL for known package manager`),
       stdout: ``,
     });
 
@@ -57,7 +57,7 @@ it.fails(`should refuse to download a known package manager from a URL in packag
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: /Illegal use of URL for known package manager/,
+      stderr: expect.stringContaining(`Illegal use of URL for known package manager`),
       stdout: ``,
     });
 
@@ -82,7 +82,7 @@ it(`should require a version to be specified`, async () => {
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: /expected a semver version/,
+      stderr: `No version specified for yarn in "packageManager" of package.json\n`,
       stdout: ``,
     });
 
@@ -92,7 +92,7 @@ it(`should require a version to be specified`, async () => {
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: /expected a semver version/,
+      stderr: expect.stringContaining(`expected a semver version`),
       stdout: ``,
     });
 
@@ -102,7 +102,7 @@ it(`should require a version to be specified`, async () => {
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: /expected a semver version/,
+      stderr: expect.stringContaining(`expected a semver version`),
       stdout: ``,
     });
   });
@@ -272,7 +272,7 @@ it(`shouldn't allow using regular Yarn commands on npm-configured projects`, asy
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: /This project is configured to use npm/,
+      stderr: expect.stringContaining(`This project is configured to use npm`),
     });
   });
 });
@@ -473,7 +473,7 @@ it(`should support disabling the network accesses from the environment`, async (
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       stdout: ``,
-      stderr: /Network access disabled by the environment/,
+      stderr: expect.stringContaining(`Network access disabled by the environment`),
       exitCode: 1,
     });
   });
@@ -845,8 +845,8 @@ it(`should download yarn classic from custom registry`, async () => {
     process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT = `1`;
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
-      stdout: /^1\.\d+\.\d+\r?\n$/,
-      stderr: /^! Corepack is about to download https:\/\/registry\.npmmirror\.com\/yarn\/-\/yarn-1\.\d+\.\d+\.tgz\r?\n$/,
+      stdout: expect.stringMatching(/^1\.\d+\.\d+\r?\n$/),
+      stderr: expect.stringMatching(/^! Corepack is about to download https:\/\/registry\.npmmirror\.com\/yarn\/-\/yarn-1\.\d+\.\d+\.tgz\r?\n$/),
     });
 
     // Should keep working with cache
@@ -894,7 +894,7 @@ it(`should download latest pnpm from custom registry`, async () => {
     await expect(runCli(cwd, [`pnpm`, `--version`], true)).resolves.toMatchObject({
       exitCode: 0,
       stdout: `pnpm: Hello from custom registry\n`,
-      stderr: /^! The local project doesn't define a 'packageManager' field\. Corepack will now add one referencing pnpm@1\.9998\.9999@sha1\./,
+      stderr: expect.stringContaining(`! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@1.9998.9999+sha1.`),
     });
 
     // Should keep working with cache
@@ -1027,12 +1027,12 @@ describe(`handle integrity checks`, () => {
     await xfs.mktempPromise(async cwd => {
       await expect(runCli(cwd, [`pnpm@1.x`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stderr: /Signature does not match/,
+        stderr: expect.stringContaining(`Signature does not match`),
         stdout: ``,
       });
-      await expect(runCli(cwd, [`yarn@stable`, `--version`], true)).resolves.toMatchObject({
+      await expect(runCli(cwd, [`pnpm@latest`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
-        stderr: /Signature does not match/,
+        stderr: expect.stringContaining(`Signature does not match`),
         stdout: ``,
       });
     });


### PR DESCRIPTION
We correct expectations against CLI output that use regular expressions. We fix tests that are easy to fix and mark tests as failing otherwise.