### PR TITLE
chore(tests): split invalid_signature test in two

### DIFF
--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1021,7 +1021,7 @@ describe(`handle integrity checks`, () => {
       });
     });
   });
-  it(`should return an error when signature does not match with a tag`, async () => {
+  it(`should return an error when signature does not match with a range`, async () => {
     process.env.TEST_INTEGRITY = `invalid_signature`; // See `_registryServer.mjs`
 
     await xfs.mktempPromise(async cwd => {
@@ -1030,6 +1030,12 @@ describe(`handle integrity checks`, () => {
         stderr: expect.stringContaining(`Signature does not match`),
         stdout: ``,
       });
+    });
+  });
+  it(`should return an error when signature does not match with a tag`, async () => {
+    process.env.TEST_INTEGRITY = `invalid_signature`; // See `_registryServer.mjs`
+
+    await xfs.mktempPromise(async cwd => {
       await expect(runCli(cwd, [`pnpm@latest`, `--version`], true)).resolves.toMatchObject({
         exitCode: 1,
         stderr: expect.stringContaining(`Signature does not match`),


### PR DESCRIPTION
Ranges and tags are not the same thing, it can be useful to have two different tests in case only one of them fail.