### PR TITLE
Use yarn nodeLinker: node-modules to make tests faster

### DIFF
--- a/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch
+++ b/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch
@@ -1,10 +1,13 @@
-diff --git a/lib/platform/package.json b/lib/platform/package.json
-index 5ea9d43740d1bdb509612376c0e9ce91d20f8b20..08d4f7327dee5e605107a343d73b2254ed08ddb9 100644
---- a/lib/platform/package.json
-+++ b/lib/platform/package.json
-@@ -1,4 +1,4 @@
- {
--    "main": "./node",
-+    "main": "./node.js",
-     "browser": "./browser"
- }
+diff --git a/package.json b/package.json
+index cbf943bcc31a864f2771e457d327e5106eba9afe..84cb1ce28a4eea4dba60bb4fa6c33a08474b2d3f 100644
+--- a/package.json
++++ b/package.json
+@@ -13,7 +13,7 @@
+     "command"
+   ],
+   "version": "3.2.1",
+-  "main": "lib/advanced/index",
++  "main": "lib/advanced/index.js",
+   "license": "MIT",
+   "sideEffects": false,
+   "repository": {

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,2 @@
+# pnp increaeses node startup time which makes tests significantly slower.
+nodeLinker: node-modules

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,12 +1350,12 @@ __metadata:
 
 "clipanion@patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch":
   version: 3.2.1
-  resolution: "clipanion@patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch::version=3.2.1&hash=cd5507"
+  resolution: "clipanion@patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch::version=3.2.1&hash=687f75"
   dependencies:
     typanion: "npm:^3.8.0"
   peerDependencies:
     typanion: "*"
-  checksum: 10c0/a833a309638d9d07eaa1e4729653944f06998ce9295bc7db5ddbffc136050e41397c4f04c25a5bdc9305ac540f5c7323b7b113a4d1da134c9c552fb3206355f6
+  checksum: 10c0/0acf7ca40c196b76b166ebb0dc7504980567cb12e5d81343d53e3e9a7e13ae24b93f338cd560114984b468b9a2b989ccabdc5247813eeb293b8757df8854d836
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This change almost halves the execution time of `main.test.ts` (from 57s to 35s on my machine using NOCK_ENV=replay). I expect similar results on CI.

The end-to-end tests run corepack in a new node process about 150 times. With the pnp linker, node is asked to require `.pnp.cjs` on every startup which significantly contributes to test time.

As an alternative, I tried removing `--require=.pnp.cjs` from `NODE_OPTIONS` in `runCli`. After all, we’re running the bundled version of corepack. But this did not work because `tests/recordRequests.js` is also required which in turn needs `better-sqlite3`.