### PR TITLE
Use NOCK_ENV=replay by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,5 +89,3 @@ jobs:
       - run: corepack yarn build # We need the stubs to run the tests
 
       - run: corepack yarn test
-        env:
-          NOCK_ENV: replay

--- a/tests/_registryServer.mjs
+++ b/tests/_registryServer.mjs
@@ -223,7 +223,7 @@ switch (process.env.AUTH_TYPE) {
   default: throw new Error(`Invalid AUTH_TYPE in env`, {cause: process.env.AUTH_TYPE});
 }
 
-if (process.env.NOCK_ENV === `replay`) {
+if (process.env.NOCK_ENV !== `record`) {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = function fetch(i) {
     if (!`${i}`.startsWith(

--- a/tests/recordRequests.js
+++ b/tests/recordRequests.js
@@ -69,7 +69,7 @@ if (process.env.NOCK_ENV === `record`) {
       headers: minimalHeaders,
     });
   };
-} else if (process.env.NOCK_ENV === `replay`) {
+} else {
   const getNockStatement = db.prepare(`SELECT body, json(headers) as headers, status FROM nocks WHERE hash = ?`);
 
   globalThis.fetch = async (input, init) => {


### PR DESCRIPTION
Replaying HTTP requests makes the tests faster and aligns them with CI.

I only realized quite late that the tests get a lot faster so I thought it would be a good idea to make that the default.