### PR TITLE
ci: enable node 23 ci tests for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,6 @@ jobs:
           - macos-latest
           - windows-latest
 
-      # Temporarily skipping Node.js 23 under Windows due to issue
-      # https://github.com/nodejs/corepack/issues/597
-      # ci vitest fails "handle integrity checks" on Windows Node.js 23
-        exclude:
-          - node: 23
-            platform: windows-latest
-
     name: "${{matrix.platform}} w/ Node.js ${{matrix.node}}.x"
     runs-on: ${{matrix.platform}}
 


### PR DESCRIPTION
## Issue

- Due to issue https://github.com/nodejs/corepack/issues/597 Windows was excluded from testing in Node.js 23 inside [.github/workflows/ci.yml](https://github.com/nodejs/corepack/blob/main/.github/workflows/ci.yml).

The above issue is no longer reproducible.

## Change

Remove the exclusion of running CI tests on Windows under Node.js 23 from the workflow [.github/workflows/ci.yml](https://github.com/nodejs/corepack/blob/main/.github/workflows/ci.yml).
