### PR TITLE
docs: caveats of multiple package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,14 @@ There are a wide variety of networking issues that can occur while running
   `curl [URL]` (ipv4) and `curl -6 [URL]` (ipv6) from your shell.
 - Check your proxy settings (see [Environment Variables](#environment-variables)).
 
+### Package manager
+If corepack is enabled, corepack will ensure that the correct package manager is used when specified in the package.lock.json  
+However, a potential pitfall is that if there are multiple installations of the same package manager.  
+
+Multiple package manager versions can cause an incorrect version of a package manager from being used, regardless if the version is package.lock.json.
+
+To verify there are not multiple version installed, see this [issue](https://github.com/nodejs/corepack/issues/659#issuecomment-2658982866).
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md).


### PR DESCRIPTION
Added documentation regarding multiple installations of a package manager with different versions.

Originally the issue was opened [here](https://github.com/nodejs/corepack/issues/659)

And it was suggested to maybe add documentation to outline the potential pitfall [here](https://github.com/nodejs/corepack/issues/659#issuecomment-2658993332).

If there is a better way to word the documentation I am contributing, please advice.
I am open to suggestions. 😄 

I am also not sure under what heading I should add it under, for now I opted to add it under `Troubleshooting` heading.

issue src #659 

I just realized now that it was suggested to add the docs to pnpm, not  corepack.
If that is still preferred, this pr can be closed 😓 