### PR TITLE
fix(use): do not throw on invalid `packageManager`

### DIFF
--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -293,19 +293,20 @@ export class Engine {
         }
 
         case `Found`: {
-          if (result.spec.name !== locator.name) {
+          const spec = result.getSpec();
+          if (spec.name !== locator.name) {
             if (transparent) {
               if (typeof locator.reference === `function`)
                 fallbackDescriptor.range = await locator.reference();
 
-              debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in a ${result.spec.name}@${result.spec.range} project`);
+              debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in a ${spec.name}@${spec.range} project`);
               return fallbackDescriptor;
             } else {
-              throw new UsageError(`This project is configured to use ${result.spec.name} because ${result.target} has a "packageManager" field`);
+              throw new UsageError(`This project is configured to use ${spec.name} because ${result.target} has a "packageManager" field`);
             }
           } else {
-            debugUtils.log(`Using ${result.spec.name}@${result.spec.range} as defined in project manifest ${result.target}`);
-            return result.spec;
+            debugUtils.log(`Using ${spec.name}@${spec.range} as defined in project manifest ${result.target}`);
+            return spec;
           }
         }
       }

--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -19,7 +19,7 @@ export abstract class BaseCommand extends Command<Context> {
           throw new UsageError(`The local project doesn't feature a 'packageManager' field - please explicit the package manager to pack, or update the manifest to reference it`);
 
         default: {
-          return [lookup.spec];
+          return [lookup.getSpec()];
         }
       }
     }

--- a/sources/commands/deprecated/Prepare.ts
+++ b/sources/commands/deprecated/Prepare.ts
@@ -42,7 +42,7 @@ export class PrepareCommand extends Command<Context> {
           throw new UsageError(`The local project doesn't feature a 'packageManager' field - please explicit the package manager to pack, or update the manifest to reference it`);
 
         default: {
-          specs.push(lookup.spec);
+          specs.push(lookup.getSpec());
         }
       }
     }

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -75,7 +75,7 @@ export async function setLocalPackageManager(cwd: string, info: PreparedPackageM
 export type LoadSpecResult =
     | {type: `NoProject`, target: string}
     | {type: `NoSpec`, target: string}
-    | {type: `Found`, target: string, readonly spec: Descriptor };
+    | {type: `Found`, target: string, getSpec: () => Descriptor};
 
 export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
   let nextCwd = initialCwd;
@@ -124,17 +124,7 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
   return {
     type: `Found`,
     target: selection.manifestPath,
-    get spec() {
-      // Lazy-loading it so we do not throw errors on commands that do not need valid spec.
-      const value = parseSpec(rawPmSpec, path.relative(initialCwd, selection.manifestPath));
-      Object.defineProperty(this, `spec`, {
-        // @ts-expect-error we should be using __proto__, despite what TS is saying
-        __proto__: null,
-        configurable: true,
-        writable: false,
-        value,
-      });
-      return value;
-    },
+    // Lazy-loading it so we do not throw errors on commands that do not need valid spec.
+    getSpec: () => parseSpec(rawPmSpec, path.relative(initialCwd, selection.manifestPath)),
   };
 }


### PR DESCRIPTION
`corepack use …` should not throw because it doesn't like the previous `packageManager` value, it's going to overwrite it anyway.