### PR TITLE
fix: replace explicit with specify as verb

### DIFF
--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -237,7 +237,7 @@ export class Engine {
    *
    * If the project doesn't include a specification file, we just assume that
    * whatever the user uses is exactly what they want to use. Since the version
-   * isn't explicited, we fallback on known good versions.
+   * isn't specified, we fallback on known good versions.
    *
    * Finally, if the project doesn't exist at all, we ask the user whether they
    * want to create one in the current project. If they do, we initialize a new

--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -13,10 +13,10 @@ export abstract class BaseCommand extends Command<Context> {
       const lookup = await specUtils.loadSpec(this.context.cwd);
       switch (lookup.type) {
         case `NoProject`:
-          throw new UsageError(`Couldn't find a project in the local directory - please explicit the package manager to pack, or run this command from a valid project`);
+          throw new UsageError(`Couldn't find a project in the local directory - please specify the package manager to pack, or run this command from a valid project`);
 
         case `NoSpec`:
-          throw new UsageError(`The local project doesn't feature a 'packageManager' field - please explicit the package manager to pack, or update the manifest to reference it`);
+          throw new UsageError(`The local project doesn't feature a 'packageManager' field - please specify the package manager to pack, or update the manifest to reference it`);
 
         default: {
           return [lookup.spec];

--- a/sources/commands/deprecated/Prepare.ts
+++ b/sources/commands/deprecated/Prepare.ts
@@ -36,10 +36,10 @@ export class PrepareCommand extends Command<Context> {
       const lookup = await specUtils.loadSpec(this.context.cwd);
       switch (lookup.type) {
         case `NoProject`:
-          throw new UsageError(`Couldn't find a project in the local directory - please explicit the package manager to pack, or run this command from a valid project`);
+          throw new UsageError(`Couldn't find a project in the local directory - please specify the package manager to pack, or run this command from a valid project`);
 
         case `NoSpec`:
-          throw new UsageError(`The local project doesn't feature a 'packageManager' field - please explicit the package manager to pack, or update the manifest to reference it`);
+          throw new UsageError(`The local project doesn't feature a 'packageManager' field - please specify the package manager to pack, or update the manifest to reference it`);
 
         default: {
           specs.push(lookup.spec);


### PR DESCRIPTION
## Issue

The adjective [explicit](https://dictionary.cambridge.org/dictionary/english/explicit) is used incorrectly as a verb.

- The issue was noticed in #643 although it does not originate from this PR.

## Change

Replace the use of "explicit" using the transitive verb [specify](https://dictionary.cambridge.org/dictionary/english/specify).

This affects only a comment and error messages.