### PR TITLE
feat: let `.corepack.env` be a lock file

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ same major line. Should you need to upgrade to a new major, use an explicit
   package manager, and to not update the Last Known Good version when it
   downloads a new version of the same major line.
 
+- `COREPACK_DEV_ENGINES_${UPPER_CASE_PACKAGE_MANAGER_NAME}` can be set to give
+  Corepack a specific version matching the range defined in `package.json`'s
+  `devEngines.packageManager` field.
+
 - `COREPACK_ENABLE_AUTO_PIN` can be set to `0` to prevent Corepack from
   updating the `packageManager` field when it detects that the local package
   doesn't list it. In general we recommend to always list a `packageManager`

--- a/tests/Up.test.ts
+++ b/tests/Up.test.ts
@@ -154,7 +154,7 @@ describe(`UpCommand`, () => {
       await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
         exitCode: 0,
         stderr: ``,
-        stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n➤ YN0000: (.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
+        stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n/),
       });
 
       try {

--- a/tests/Up.test.ts
+++ b/tests/Up.test.ts
@@ -1,5 +1,6 @@
 import {ppath, xfs, npath}                from '@yarnpkg/fslib';
 import process                            from 'node:process';
+import {parseEnv}                         from 'node:util';
 import {describe, beforeEach, it, expect} from 'vitest';
 
 import {runCli}                           from './_runCli';
@@ -132,5 +133,43 @@ describe(`UpCommand`, () => {
         });
       });
     });
+  });
+
+  it(`should update the ".corepack.env" file from the current project`, async t => {
+    // Skip that test on Node.js 18.x as it lacks support for .env files.
+    if (process.version.startsWith(`v18.`)) t.skip();
+    await Promise.all([
+      `COREPACK_DEV_ENGINES_YARN=1.1.0\n`,
+      `\nCOREPACK_DEV_ENGINES_YARN=1.1.0\n`,
+      `COREPACK_DEV_ENGINES_YARN=1.1.0`,
+      `\nCOREPACK_DEV_ENGINES_YARN=1.1.0`,
+      `FOO=bar\nCOREPACK_DEV_ENGINES_YARN=1.1.0\n`,
+      `FOO=bar\nCOREPACK_DEV_ENGINES_YARN=1.1.0`,
+    ].map(originalEnv => xfs.mktempPromise(async cwd => {
+      await xfs.writeJsonPromise(ppath.join(cwd, `package.json`), {
+        devEngines: {packageManager: {name: `yarn`, version: `1.x || 2.x`}},
+      });
+      await xfs.writeFilePromise(ppath.join(cwd, `.corepack.env`), originalEnv);
+
+      await expect(runCli(cwd, [`up`])).resolves.toMatchObject({
+        exitCode: 0,
+        stderr: ``,
+        stdout: expect.stringMatching(/^Installing yarn@2\.4\.3 in the project\.\.\.\n\n➤ YN0000: (.*\n)+➤ YN0000: Done in \d+s \d+ms\n$/),
+      });
+
+      try {
+        await expect(xfs.readFilePromise(ppath.join(cwd, `.corepack.env`), `utf-8`).then(parseEnv)).resolves.toMatchObject({
+          COREPACK_DEV_ENGINES_YARN: `2.4.3+sha512.8dd9fedc5451829619e526c56f42609ad88ae4776d9d3f9456d578ac085115c0c2f0fb02bb7d57fd2e1b6e1ac96efba35e80a20a056668f61c96934f67694fd0`,
+        });
+      } catch (cause) {
+        throw new Error(JSON.stringify(originalEnv), {cause});
+      }
+
+      await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
+        exitCode: 0,
+        stdout: `2.4.3\n`,
+        stderr: ``,
+      });
+    })));
   });
 });

--- a/tests/Use.test.ts
+++ b/tests/Use.test.ts
@@ -294,7 +294,7 @@ describe(`UseCommand`, () => {
       await expect(runCli(cwd, [`use`, `yarn@1.22.4`])).resolves.toMatchObject({
         exitCode: 0,
         stderr: ``,
-        stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\nyarn install v1\.22\.4\ninfo No lockfile found\.\n(.*\n)+Done in \d+\.\d+s\.\n$/),
+        stdout: expect.stringMatching(/^Installing yarn@1\.22\.4 in the project\.\.\.\n\n/),
       });
 
       try {


### PR DESCRIPTION
With https://github.com/nodejs/corepack/pull/642 and https://github.com/nodejs/corepack/pull/643 landed, we can consider using `.corepack.env` as a lockfile. If the `package.json` defines a `devEngines.packageManager`, we can accept an env variable that defines the exact version Corepack should be using; if that version is put in a `.corepack.env` (Node.js 20+ users only), it's effectively a lockfile.

I'm not a fan of the env variable name chosen, happy to use a different one.

Fixes: https://github.com/nodejs/corepack/issues/402
Fixes: https://github.com/nodejs/corepack/issues/95
Fixes: https://github.com/nodejs/corepack/issues/682