### PR TITLE
Removes npm from the possible options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 Corepack is a zero-runtime-dependency Node.js script that acts as a bridge
 between Node.js projects and the package managers they are intended to be used
-with during development. In practical terms, **Corepack lets you use Yarn, npm,
-and pnpm without having to install them**.
+with during development. In practical terms, **Corepack lets you use Yarn and pnpm without having to install them**.
 
 ## How to Install
 
@@ -71,7 +70,7 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 ### When Building Packages
 
 Just use your package managers as you usually would. Run `yarn install` in Yarn
-projects, `pnpm install` in pnpm projects, and `npm` in npm projects. Corepack
+projects and `pnpm install` in pnpm projects. Corepack
 will catch these calls, and depending on the situation:
 
 - **If the local project is configured for the package manager you're using**,
@@ -100,7 +99,7 @@ Here, `yarn` is the name of the package manager, specified at version `3.2.3`,
 along with the SHA-224 hash of this version for validation.
 `packageManager@x.y.z` is required. The hash is optional but strongly
 recommended as a security practice. Permitted values for the package manager are
-`yarn`, `npm`, and `pnpm`.
+`yarn` and `pnpm`.
 
 You can also provide a URL to a `.js` file (which will be interpreted as a
 CommonJS module) or a `.tgz` file (which will be interpreted as a package, and
@@ -198,9 +197,8 @@ Clears the local `COREPACK_HOME` cache directory.
 
 This command will detect where Corepack is installed and will create shims next
 to it for each of the specified package managers (or all of them if the command
-is called without parameters). Note that the npm shims will not be installed
-unless explicitly requested, as npm is currently distributed with Node.js
-through other means.
+is called without parameters). Note that the npm shims will not be installed,
+as npm is directly installed with Node.js.
 
 If the file system where the `corepack` binary is located is read-only, this
 command will fail. A workaround is to add the binaries as alias in your
@@ -211,8 +209,6 @@ alias yarn="corepack yarn"
 alias yarnpkg="corepack yarnpkg"
 alias pnpm="corepack pnpm"
 alias pnpx="corepack pnpx"
-alias npm="corepack npm"
-alias npx="corepack npx"
 ```
 
 On Windows PowerShell, you can add functions using the `$PROFILE` automatic
@@ -223,8 +219,6 @@ echo "function yarn { corepack yarn `$args }" >> $PROFILE
 echo "function yarnpkg { corepack yarnpkg `$args }" >> $PROFILE
 echo "function pnpm { corepack pnpm `$args }" >> $PROFILE
 echo "function pnpx { corepack pnpx `$args }" >> $PROFILE
-echo "function npm { corepack npm `$args }" >> $PROFILE
-echo "function npx { corepack npx `$args }" >> $PROFILE
 ```
 
 ### `corepack disable [... name]`
@@ -302,7 +296,7 @@ same major line. Should you need to upgrade to a new major, use an explicit
   ask for user input before starting the download.
 
 - `COREPACK_ENABLE_UNSAFE_CUSTOM_URLS` can be set to `1` to allow use of
-  custom URLs to load a package manager known by Corepack (`yarn`, `npm`, and
+  custom URLs to load a package manager known by Corepack (`yarn` and
   `pnpm`).
 
 - `COREPACK_ENABLE_NETWORK` can be set to `0` to prevent Corepack from accessing

--- a/config.json
+++ b/config.json
@@ -1,42 +1,5 @@
 {
   "definitions": {
-    "npm": {
-      "default": "11.1.0+sha1.dba08f7d0f5301ebedaf968b4f74b2282f97a750",
-      "fetchLatestFrom": {
-        "type": "npm",
-        "package": "npm"
-      },
-      "transparent": {
-        "commands": [
-          [
-            "npm",
-            "init"
-          ],
-          [
-            "npx"
-          ]
-        ]
-      },
-      "ranges": {
-        "*": {
-          "url": "https://registry.npmjs.org/npm/-/npm-{}.tgz",
-          "bin": {
-            "npm": "./bin/npm-cli.js",
-            "npx": "./bin/npx-cli.js"
-          },
-          "registry": {
-            "type": "npm",
-            "package": "npm"
-          },
-          "commands": {
-            "use": [
-              "npm",
-              "install"
-            ]
-          }
-        }
-      }
-    },
     "pnpm": {
       "default": "10.5.2+sha1.ca68c0441df195b7e2992f1d1cb12fb731f82d78",
       "fetchLatestFrom": {

--- a/package.json
+++ b/package.json
@@ -71,17 +71,11 @@
       "yarnpkg": "./dist/yarnpkg.js"
     },
     "executableFiles": [
-      "./dist/npm.js",
-      "./dist/npx.js",
       "./dist/pnpm.js",
       "./dist/pnpx.js",
       "./dist/yarn.js",
       "./dist/yarnpkg.js",
       "./dist/corepack.js",
-      "./shims/npm",
-      "./shims/npm.ps1",
-      "./shims/npx",
-      "./shims/npx.ps1",
       "./shims/pnpm",
       "./shims/pnpm.ps1",
       "./shims/pnpx",

--- a/sources/commands/Disable.ts
+++ b/sources/commands/Disable.ts
@@ -1,11 +1,11 @@
-import {Command, Option, UsageError}                                     from 'clipanion';
-import fs                                                                from 'fs';
-import path                                                              from 'path';
-import which                                                             from 'which';
+import {Command, Option, UsageError}                           from 'clipanion';
+import fs                                                      from 'fs';
+import path                                                    from 'path';
+import which                                                   from 'which';
 
-import {Context}                                                         from '../main';
-import type {NodeError}                                                  from '../nodeUtils';
-import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types';
+import {Context}                                               from '../main';
+import type {NodeError}                                        from '../nodeUtils';
+import {isSupportedPackageManager, SupportedPackageManagerSet} from '../types';
 
 export class DisableCommand extends Command<Context> {
   static paths = [
@@ -47,7 +47,7 @@ export class DisableCommand extends Command<Context> {
       installDirectory = path.dirname(await which(`corepack`));
 
     const names = this.names.length === 0
-      ? SupportedPackageManagerSetWithoutNpm
+      ? SupportedPackageManagerSet
       : this.names;
 
     const allBinNames: Array<string> = [];

--- a/sources/commands/Enable.ts
+++ b/sources/commands/Enable.ts
@@ -1,11 +1,11 @@
-import cmdShim                                                           from '@zkochan/cmd-shim';
-import {Command, Option, UsageError}                                     from 'clipanion';
-import fs                                                                from 'fs';
-import path                                                              from 'path';
-import which                                                             from 'which';
+import cmdShim                                                 from '@zkochan/cmd-shim';
+import {Command, Option, UsageError}                           from 'clipanion';
+import fs                                                      from 'fs';
+import path                                                    from 'path';
+import which                                                   from 'which';
 
-import {Context}                                                         from '../main';
-import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types';
+import {Context}                                               from '../main';
+import {isSupportedPackageManager, SupportedPackageManagerSet} from '../types';
 
 export class EnableCommand extends Command<Context> {
   static paths = [
@@ -57,7 +57,7 @@ export class EnableCommand extends Command<Context> {
       throw new Error(`Assertion failed: The stub folder doesn't exist`);
 
     const names = this.names.length === 0
-      ? SupportedPackageManagerSetWithoutNpm
+      ? SupportedPackageManagerSet
       : this.names;
 
     const allBinNames: Array<string> = [];

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -401,15 +401,9 @@ export async function runVersion(locator: Locator, installSpec: InstallSpec & {s
     throw new Error(`Assertion failed: Unable to locate path for bin '${binName}'`);
 
   // @ts-expect-error - Missing types
-  if (!Module.enableCompileCache) {
-    // Node.js segfaults when using npm@>=9.7.0 and v8-compile-cache
-    // $ docker run -it node:20.3.0-slim corepack npm@9.7.1 --version
-    // [SIGSEGV]
-    if (locator.name !== `npm` || semverLt(locator.reference, `9.7.0`)) {
-      // @ts-expect-error - No types
-      await import(`v8-compile-cache`);
-    }
-  }
+  if (!Module.enableCompileCache)
+    // @ts-expect-error - No types
+    await import(`v8-compile-cache`);
 
   // We load the binary into the current process,
   // while making it think it was spawned.

--- a/sources/types.ts
+++ b/sources/types.ts
@@ -2,7 +2,6 @@ export type BinSpec = {[key: string]: string};
 export type BinList = Array<string>;
 
 export enum SupportedPackageManagers {
-  Npm = `npm`,
   Pnpm = `pnpm`,
   Yarn = `yarn`,
 }
@@ -10,13 +9,6 @@ export enum SupportedPackageManagers {
 export const SupportedPackageManagerSet = new Set<SupportedPackageManagers>(
   Object.values(SupportedPackageManagers),
 );
-
-export const SupportedPackageManagerSetWithoutNpm = new Set<SupportedPackageManagers>(
-  Object.values(SupportedPackageManagers),
-);
-
-// npm is distributed with Node as a builtin; we don't want Corepack to override it unless the npm team is on board
-SupportedPackageManagerSetWithoutNpm.delete(SupportedPackageManagers.Npm);
 
 export function isSupportedPackageManager(value: string): value is SupportedPackageManagers {
   return SupportedPackageManagerSet.has(value as SupportedPackageManagers);

--- a/tests/Disable.test.ts
+++ b/tests/Disable.test.ts
@@ -1,13 +1,13 @@
-import {Filename, ppath, xfs, npath}          from '@yarnpkg/fslib';
-import {delimiter}                            from 'node:path';
-import process                                from 'node:process';
-import {describe, beforeEach, it, expect}     from 'vitest';
+import {Filename, ppath, xfs, npath}      from '@yarnpkg/fslib';
+import {delimiter}                        from 'node:path';
+import process                            from 'node:process';
+import {describe, beforeEach, it, expect} from 'vitest';
 
-import {Engine}                               from '../sources/Engine';
-import {SupportedPackageManagerSetWithoutNpm} from '../sources/types';
+import {Engine}                           from '../sources/Engine';
+import {SupportedPackageManagerSet}       from '../sources/types';
 
-import {makeBin, getBinaryNames}              from './_binHelpers';
-import {runCli}                               from './_runCli';
+import {makeBin, getBinaryNames}          from './_binHelpers';
+import {runCli}                           from './_runCli';
 
 const engine = new Engine();
 
@@ -22,7 +22,7 @@ describe(`DisableCommand`, () => {
       const corepackBin = await makeBin(cwd, `corepack` as Filename);
       const dontRemoveBin = await makeBin(cwd, `dont-remove` as Filename);
 
-      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
+      for (const packageManager of SupportedPackageManagerSet)
         for (const binName of engine.getBinariesFor(packageManager))
           for (const variant of getBinaryNames(binName))
             await makeBin(cwd, variant as Filename, {ignorePlatform: true});
@@ -47,7 +47,7 @@ describe(`DisableCommand`, () => {
     await xfs.mktempPromise(async cwd => {
       const dontRemoveBin = await makeBin(cwd, `dont-remove` as Filename);
 
-      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
+      for (const packageManager of SupportedPackageManagerSet)
         for (const binName of engine.getBinariesFor(packageManager))
           for (const variant of getBinaryNames(binName))
             await makeBin(cwd, variant as Filename, {ignorePlatform: true});
@@ -66,7 +66,7 @@ describe(`DisableCommand`, () => {
     await xfs.mktempPromise(async cwd => {
       const binNames = new Set<string>();
 
-      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
+      for (const packageManager of SupportedPackageManagerSet)
         for (const binName of engine.getBinariesFor(packageManager))
           for (const variant of getBinaryNames(binName))
             binNames.add(variant);

--- a/tests/Enable.test.ts
+++ b/tests/Enable.test.ts
@@ -1,13 +1,13 @@
-import {Filename, ppath, xfs, npath}                                    from '@yarnpkg/fslib';
-import {delimiter}                                                      from 'node:path';
-import process                                                          from 'node:process';
-import {describe, beforeEach, it, expect}                               from 'vitest';
+import {Filename, ppath, xfs, npath}                          from '@yarnpkg/fslib';
+import {delimiter}                                            from 'node:path';
+import process                                                from 'node:process';
+import {describe, beforeEach, it, expect}                     from 'vitest';
 
-import {Engine}                                                         from '../sources/Engine';
-import {SupportedPackageManagers, SupportedPackageManagerSetWithoutNpm} from '../sources/types';
+import {Engine}                                               from '../sources/Engine';
+import {SupportedPackageManagers, SupportedPackageManagerSet} from '../sources/types';
 
-import {makeBin, getBinaryNames}                                        from './_binHelpers';
-import {runCli}                                                         from './_runCli';
+import {makeBin, getBinaryNames}                              from './_binHelpers';
+import {runCli}                                               from './_runCli';
 
 const engine = new Engine();
 
@@ -34,7 +34,7 @@ describe(`EnableCommand`, () => {
       });
 
       const expectedEntries: Array<string> = [ppath.basename(corepackBin)];
-      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
+      for (const packageManager of SupportedPackageManagerSet)
         for (const binName of engine.getBinariesFor(packageManager))
           expectedEntries.push(...getBinaryNames(binName));
 
@@ -57,7 +57,7 @@ describe(`EnableCommand`, () => {
       });
 
       const expectedEntries: Array<string> = [ppath.basename(corepackBin)];
-      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
+      for (const packageManager of SupportedPackageManagerSet)
         for (const binName of engine.getBinariesFor(packageManager))
           expectedEntries.push(...getBinaryNames(binName));
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -570,7 +570,7 @@ it(`should use the closest matching packageManager field`, async () => {
       packageManager: `pnpm@10.5.2`,
     });
 
-    await expect(runCli(ppath.join(cwd, `foo` as PortablePath), [`p npm`, `--version`])).resolves.toMatchObject({
+    await expect(runCli(ppath.join(cwd, `foo` as PortablePath), [`pnpm`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
       stderr: ``,
       stdout: `10.5.2\n`,
@@ -582,11 +582,14 @@ it(`should expose its root to spawned processes`, async () => {
   await xfs.mktempPromise(async cwd => {
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
       packageManager: `pnpm@10.5.2`,
+      scripts: {
+        env: `node -p process.env.COREPACK_ROOT`,
+      },
     });
 
     await expect(runCli(cwd, [`pnpm`, `run`, `env`])).resolves.toMatchObject({
       exitCode: 0,
-      stdout: expect.stringContaining(`COREPACK_ROOT=${npath.dirname(__dirname)}`),
+      stdout: expect.stringContaining(npath.dirname(__dirname)),
     });
   });
 });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -149,9 +149,6 @@ const testedPackageManagers: Array<[string, string] | [string, string, string]> 
   [`pnpm`, `6.6.2`],
   [`pnpm`, `6.6.2+sha1.7b4d6b176c1b93b5670ed94c24babb7d80c13854`],
   [`pnpm`, `6.6.2+sha224.eb5c0acad3b0f40ecdaa2db9aa5a73134ad256e17e22d1419a2ab073`],
-  [`npm`, `6.14.2`],
-  [`npm`, `6.14.2+sha1.f057d35cd4792c4c511bb1fa332edb43143d07b0`],
-  [`npm`, `6.14.2+sha224.50512c1eb404900ee78586faa6d756b8d867ff46a328e6fb4cdf3a87`],
 ];
 
 for (const [name, version, expectedVersion = version.split(`+`, 1)[0]] of testedPackageManagers) {
@@ -247,11 +244,11 @@ it(`should ignore the packageManager field when found within a node_modules vend
     });
 
     await xfs.writeJsonPromise(ppath.join(cwd, `node_modules/foo/package.json` as PortablePath), {
-      packageManager: `npm@6.14.2`,
+      packageManager: `pnpm@10.5.2`,
     });
 
     await xfs.writeJsonPromise(ppath.join(cwd, `node_modules/@foo/bar/package.json` as PortablePath), {
-      packageManager: `npm@6.14.2`,
+      packageManager: `pnpm@10.5.2`,
     });
 
     await expect(runCli(ppath.join(cwd, `node_modules/foo` as PortablePath), [`yarn`, `--version`])).resolves.toMatchObject({
@@ -304,6 +301,7 @@ describe(`should handle invalid devEngines values`, () => {
       });
     });
   });
+
   it(`warn on array values`, async () => {
     await xfs.mktempPromise(async cwd => {
       await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as PortablePath), {
@@ -569,13 +567,13 @@ it(`should use the closest matching packageManager field`, async () => {
     });
 
     await xfs.writeJsonPromise(ppath.join(cwd, `foo/package.json` as PortablePath), {
-      packageManager: `npm@6.14.2`,
+      packageManager: `pnpm@10.5.2`,
     });
 
-    await expect(runCli(ppath.join(cwd, `foo` as PortablePath), [`npm`, `--version`])).resolves.toMatchObject({
+    await expect(runCli(ppath.join(cwd, `foo` as PortablePath), [`p npm`, `--version`])).resolves.toMatchObject({
       exitCode: 0,
       stderr: ``,
-      stdout: `6.14.2\n`,
+      stdout: `10.5.2\n`,
     });
   });
 });
@@ -583,33 +581,33 @@ it(`should use the closest matching packageManager field`, async () => {
 it(`should expose its root to spawned processes`, async () => {
   await xfs.mktempPromise(async cwd => {
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
-      packageManager: `npm@6.14.2`,
+      packageManager: `pnpm@10.5.2`,
     });
 
-    await expect(runCli(cwd, [`npm`, `run`, `env`])).resolves.toMatchObject({
+    await expect(runCli(cwd, [`pnpm`, `run`, `env`])).resolves.toMatchObject({
       exitCode: 0,
       stdout: expect.stringContaining(`COREPACK_ROOT=${npath.dirname(__dirname)}`),
     });
   });
 });
 
-it(`shouldn't allow using regular Yarn commands on npm-configured projects`, async () => {
+it(`shouldn't allow using regular Yarn commands on pnpm-configured projects`, async () => {
   await xfs.mktempPromise(async cwd => {
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
-      packageManager: `npm@6.14.2`,
+      packageManager: `pnpm@10.5.2`,
     });
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       exitCode: 1,
-      stderr: expect.stringContaining(`This project is configured to use npm`),
+      stderr: expect.stringContaining(`This project is configured to use pnpm`),
     });
   });
 });
 
-it(`should allow using transparent commands on npm-configured projects`, async () => {
+it(`should allow using transparent commands on pnpm-configured projects`, async () => {
   await xfs.mktempPromise(async cwd => {
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
-      packageManager: `npm@6.14.2`,
+      packageManager: `pnpm@10.5.2`,
     });
 
     await expect(runCli(cwd, [`yarn`, `dlx`, `--help`])).resolves.toMatchObject({
@@ -730,24 +728,6 @@ it(`should allow updating the pinned version using the "corepack install -g" com
 
     await expect(runCli(cwd, [`yarn`, `--version`])).resolves.toMatchObject({
       stdout: `1.0.0\n`,
-      exitCode: 0,
-    });
-  });
-});
-
-it(`should allow to call "corepack install -g" with a tag`, async () => {
-  await xfs.mktempPromise(async cwd => {
-    await expect(runCli(cwd, [`install`, `-g`, `npm@latest-7`])).resolves.toMatchObject({
-      exitCode: 0,
-      stderr: ``,
-    });
-
-    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
-      // empty package.json file
-    });
-
-    await expect(runCli(cwd, [`npm`, `--version`])).resolves.toMatchObject({
-      stdout: expect.stringMatching(/^7\./),
       exitCode: 0,
     });
   });


### PR DESCRIPTION
I never intended for Corepack to offer npm as an option _without its maintainers enabling it themselves_. It was supported through an explicit `corepack enable npm` mostly to make sure that whatever design we picked would keep npm in mind, so that in the event they'd one day be interested to join us it'd just be a flip of a switch. It wasn't a requirement (npm users already have their nice developer experience, my goal was to improve Yarn's and pnpm's devx at no cost for anyone).

To clarify that and make it _super duper clear_ that making Corepack stable won't impact npm users in any shape or form, I propose this PR to remove `npm` from the possible options. It's no longer possible to activate it using `corepack enable npm`. I erased any mention of it, including from the tests.

Also, addressing my own comment:
https://github.com/nodejs/corepack/pull/418#issuecomment-1982978140

> get formal approval from someone from the actual npm team. As far as I'm aware you're working on a competing product, which makes you kind of the wrong person to make this request (part of why I didn't merge my own https://github.com/nodejs/corepack/pull/407).

This was requested/suggested by TSC members unrelated to Yarn / pnpm. Since this is a Node.js project, I don't have objection to them requesting this change.

Closes #418 