### PR TITLE
docs: add deprecated commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,19 @@ range specified in `devEngines.packageManager.version`, or fallback to the
 same major line. Should you need to upgrade to a new major, use an explicit
 `corepack use {name}@latest` call (or simply `corepack use {name}`).
 
+## Utility Commands (deprecated)
+
+The utility commands `corepack hydrate` and `corepack prepare` were deprecated with [corepack@0.20.0](https://github.com/nodejs/corepack/releases/tag/v0.20.0).
+It is recommended to use the replacement commands as shown in the following table:
+
+| Deprecated command                                | Replacement command                                    |
+| ------------------------------------------------- | ------------------------------------------------------ |
+| `corepack hydrate path/to/archive.tgz`            | `corepack install -g --cache-only path/to/archive.tgz` |
+| `corepack hydrate path/to/archive.tgz --activate` | `corepack install -g path/to/archive.tgz`              |
+| `corepack prepare foo@1.2.3`                      | `corepack install -g --cache-only foo@1.2.3`           |
+| `corepack prepare foo@1.2.3 --activate`           | `corepack install -g foo@1.2.3`                        |
+| `corepack prepare -o ...`                         | `corepack pack -o ...`                                 |
+
 ## Environment Variables
 
 - `COREPACK_DEFAULT_TO_LATEST` can be set to `0` in order to instruct Corepack


### PR DESCRIPTION
- partially resolves issue https://github.com/nodejs/corepack/issues/624

## Situation

[corepack@0.20.0](https://github.com/nodejs/corepack/releases/tag/v0.20.0) deprecated commands

- `corepack prepare`
- `corepack hydrate`

The commands are still available and they are undocumented in the [README](https://github.com/nodejs/corepack/blob/main/README.md) file.
The migration to current commands is also undocumented.

The deprecated commands were previously documented as follows:

---

### `corepack prepare [... name@version]`

| Option        | Description                                                             |
| ------------- | ----------------------------------------------------------------------- |
| `--all`       | Prepare the "Last Known Good" version of all supported package managers |
| `-o,--output` | Also generate an archive containing the package managers                |
| `--activate`  | Also update the "Last Known Good" release                               |

This command will download the given package managers (or the one configured for
the local project if no argument is passed in parameter) and store it within the
Corepack cache. If the `-o,--output` flag is set (optionally with a path as
parameter), an archive will also be generated that can be used by the
`corepack hydrate` command.

### `corepack hydrate <path/to/corepack.tgz>`

| Option       | Description                               |
| ------------ | ----------------------------------------- |
| `--activate` | Also update the "Last Known Good" release |

This command will retrieve the given package manager from the specified archive
and will install it within the Corepack cache, ready to be used without further
network interaction.

---

## Change

Add a section to the [README](https://github.com/nodejs/corepack/blob/main/README.md) that lists the deprecated commands and their replacement commands.
