### PR TITLE
chore: debug text typo

### DIFF
--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -288,7 +288,7 @@ export class Engine {
             await specUtils.setLocalPackageManager(path.dirname(result.target), installSpec);
           }
 
-          debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in the absence of "packageManage" field in ${result.target}`);
+          debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in the absence of "packageManager" field in ${result.target}`);
           return fallbackDescriptor;
         }
 


### PR DESCRIPTION
Fix typo in

https://github.com/nodejs/corepack/blob/679bcefda571e99bcf021d48b502e56d66d6eac0/sources/Engine.ts#L291

should be `packageManager`

The text was added by https://github.com/nodejs/corepack/pull/538