### PR TITLE
chore(publish): add `--provenance`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -48,10 +50,10 @@ jobs:
           restore-keys: |
             ${{runner.os}}-yarn-
 
+      - run: corepack yarn install --immutable
+
       - name: Publish to the npm registry
-        run: |
-          corepack yarn install --immutable
-          corepack yarn npm publish
+        run: corepack yarn npm publish --provenance
         env:
           YARN_NPM_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "license": "MIT",
-  "packageManager": "yarn@4.6.0+sha512.5383cc12567a95f1d668fbe762dfe0075c595b4bfff433be478dbbe24e05251a8e8c3eb992a986667c1d53b6c3a9c85b8398c35a960587fbd9fa3a0915406728",
+  "packageManager": "yarn@4.9.0+sha224.dce6c5df199861784bd9b0eecb2a228df97e3f18a02b1bb75ff98383",
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/node": "^20.4.6",


### PR DESCRIPTION
Latest version of Yarn added support for that, previous attempt in https://github.com/nodejs/corepack/pull/520 failed probably for a permission issue.