### PR TITLE
chore!: remove Node.js 18.x and 23.x usage, add 24.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,20 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 18
           - 20
           - 22
-          - 23
+          - 24
         platform:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+
+      # Temporarily skipping Node.js 24 under Windows due to issue
+      # https://github.com/nodejs/corepack/issues/715
+      # vitest fails "handle integrity checks" on Windows with Node.js 24.x
+        exclude:
+          - node: 24
+            platform: windows-latest
 
     name: "${{matrix.platform}} w/ Node.js ${{matrix.node}}.x"
     runs-on: ${{matrix.platform}}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/nodejs/corepack.git"
   },
   "engines": {
-    "node": "^18.17.1 || ^20.10.0 || >=22.11.0"
+    "node": "^20.10.0 || ^22.11.0 || >=24.0.0"
   },
   "exports": {
     "./package.json": "./package.json"


### PR DESCRIPTION
- closes https://github.com/nodejs/corepack/issues/716

## Situation

Referring to the [Node.js release schedule](https://github.com/nodejs/release#release-schedule) the following release transitions have occurred:

| Node.js | Status      | Date       |
| ------- | ----------- | ---------- |
| `18.x`  | End-of-Life | 2025-04-30 |
| `23.x`  | End-of-Life | 2025-06-01 |
| `24.x`  | Release     | 2025-05-06 |

## Change

1. In [package.json](https://github.com/nodejs/corepack/blob/main/package.json) remove `18.x`, remove `23.x`, continue to include `24.x` and above:

```json
  "engines": {
    "node": "^20.10.0 || ^22.11.0 || >=24.0.0"
  },
```

2. In [.github/workflows/ci.yml](https://github.com/nodejs/corepack/blob/main/.github/workflows/ci.yml) remove `18.x`, remove `23.x`, add `24.x` with Windows exclusion, due to issue https://github.com/nodejs/corepack/issues/715:

```yml
      matrix:
        node:
          - 20
          - 22
          - 24
        platform:
          - ubuntu-latest
          - macos-latest
          - windows-latest
```
