### PR TITLE
chore: fix permissions in the `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,12 +8,14 @@ env:
   YARN_ENABLE_GLOBAL_CACHE: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created:  ${{ steps.release.outputs.release_created }}
       release_tag:  ${{ steps.release.outputs.tag_name }}
@@ -30,6 +32,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The previous release workflow failed at the step where it's supposed to upload the release archive to the GH release: https://github.com/nodejs/corepack/actions/runs/15393039865
