### PR TITLE
docs(corepack-version): reference node 24 as latest default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and pnpm without having to install them**.
 
 ### Default Installs
 
-Corepack is [distributed by default with all recent Node.js versions](https://nodejs.org/api/corepack.html).
+Corepack is [distributed till Node.js 24](https://nodejs.org/api/corepack.html).
 Run `corepack enable` to install the required Yarn and pnpm binaries on your path.
 
 ### Manual Installs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and pnpm without having to install them**.
 
 ### Default Installs
 
-Corepack is [distributed till Node.js 24](https://nodejs.org/api/corepack.html).
+Corepack is [distributed with Node.js 18 to Node.js 24](https://nodejs.org/api/corepack.html). However, it stopped being included starting with Node.js 25. 
 Run `corepack enable` to install the required Yarn and pnpm binaries on your path.
 
 ### Manual Installs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and pnpm without having to install them**.
 
 ### Default Installs
 
-Corepack is [distributed with Node.js 18 to Node.js 24](https://nodejs.org/api/corepack.html). However, it stopped being included starting with Node.js 25. 
+Corepack is [distributed with Node.js 14 to Node.js 24](https://nodejs.org/api/corepack.html). However, it stopped being included starting with Node.js 25.
 Run `corepack enable` to install the required Yarn and pnpm binaries on your path.
 
 ### Manual Installs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and pnpm without having to install them**.
 
 ### Default Installs
 
-Corepack is [distributed with Node.js 14 to Node.js 24](https://nodejs.org/api/corepack.html). However, it stopped being included starting with Node.js 25.
+Corepack is distributed with Node.js from version 14.19.0 up to (but not including) 25.0.0.
 Run `corepack enable` to install the required Yarn and pnpm binaries on your path.
 
 ### Manual Installs


### PR DESCRIPTION
closes #722