### PR TITLE
fix: ignoring .corepack.env with "corepack use" command

### DIFF
--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -9,8 +9,10 @@ export abstract class BaseCommand extends Command<Context> {
   async resolvePatternsToDescriptors({patterns}: {patterns: Array<string>}) {
     const resolvedSpecs = patterns.map(pattern => specUtils.parseSpec(pattern, `CLI arguments`, {enforceExactVersion: false}));
 
+    // Always load spec to ensure .corepack.env is read before any registry calls
+    const lookup = await specUtils.loadSpec(this.context.cwd);
+
     if (resolvedSpecs.length === 0) {
-      const lookup = await specUtils.loadSpec(this.context.cwd);
       switch (lookup.type) {
         case `NoProject`:
           throw new UsageError(`Couldn't find a project in the local directory - please specify the package manager to pack, or run this command from a valid project`);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1317,6 +1317,28 @@ it(`should download latest pnpm from custom registry`, async () => {
   });
 });
 
+it(`should use COREPACK_NPM_REGISTRY from .corepack.env for "corepack use" command`, async t => {
+  // Skip that test on Node.js 18.x as it lacks support for .env files.
+  if (process.version.startsWith(`v18.`)) t.skip();
+
+  process.env.COREPACK_ENABLE_NETWORK = `0`;
+
+  await xfs.mktempPromise(async cwd => {
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {});
+
+    // Set COREPACK_NPM_REGISTRY in .corepack.env
+    await xfs.writeFilePromise(ppath.join(cwd, `.corepack.env` as Filename), `COREPACK_NPM_REGISTRY=http://custom-registry.example.com\n`);
+
+    // "corepack use pnpm" should read .corepack.env and use the custom registry
+    // When network is disabled, the error message should contain the custom registry URL
+    await expect(runCli(cwd, [`use`, `pnpm`])).resolves.toMatchObject({
+      stdout: ``,
+      stdout: expect.stringContaining(`custom-registry.example.com`),
+      exitCode: 1,
+    });
+  });
+});
+
 describe(`should pick up COREPACK_INTEGRITY_KEYS from env`, () => {
   beforeEach(() => {
     process.env.AUTH_TYPE = `COREPACK_NPM_TOKEN`; // See `_registryServer.mjs`


### PR DESCRIPTION
Fixes https://github.com/nodejs/corepack/issues/741

Also adding a test that demonstrates `.corepack.env` is ignored when running `corepack use <pkg>`.
 