### PR TITLE
chore(tests): prefer `--install-directory` over `PATH` manipulation

### DIFF
--- a/tests/Disable.test.ts
+++ b/tests/Disable.test.ts
@@ -102,12 +102,14 @@ describe(`DisableCommand`, () => {
       await xfs.mkdirPromise(ppath.join(cwd, `switch/bin`), {recursive: true});
       await xfs.writeFilePromise(ppath.join(cwd, `switch/bin/yarn`), `hello`);
 
-      await xfs.linkPromise(
+      await xfs.symlinkPromise(
         ppath.join(cwd, `switch/bin/yarn`),
         ppath.join(cwd, `yarn`),
       );
 
       await expect(runCli(cwd, [`disable`, `--install-directory=${npath.fromPortablePath(cwd)}`])).resolves.toMatchObject({
+        stdout: ``,
+        stderr: expect.stringMatching(/^yarn is already installed in .+ and points to a Yarn Switch install - skipping\n$/),
         exitCode: 0,
       });
 

--- a/tests/Disable.test.ts
+++ b/tests/Disable.test.ts
@@ -107,7 +107,7 @@ describe(`DisableCommand`, () => {
         ppath.join(cwd, `yarn`),
       );
 
-      await expect(runCli(cwd, [`disable`])).resolves.toMatchObject({
+      await expect(runCli(cwd, [`disable`, `--install-directory=${npath.fromPortablePath(cwd)}`])).resolves.toMatchObject({
         exitCode: 0,
       });
 

--- a/tests/Disable.test.ts
+++ b/tests/Disable.test.ts
@@ -80,8 +80,7 @@ describe(`DisableCommand`, () => {
       const dontRemoveBin = await makeBin(cwd, `dont-remove` as Filename);
       binNames.add(ppath.basename(dontRemoveBin));
 
-      process.env.PATH = `${npath.fromPortablePath(cwd)}${delimiter}${process.env.PATH}`;
-      await expect(runCli(cwd, [`disable`, `yarn`])).resolves.toMatchObject({
+      await expect(runCli(cwd, [`disable`, `--install-directory=${npath.fromPortablePath(cwd)}`, `yarn`])).resolves.toMatchObject({
         exitCode: 0,
       });
 

--- a/tests/Disable.test.ts
+++ b/tests/Disable.test.ts
@@ -82,6 +82,8 @@ describe(`DisableCommand`, () => {
 
       await expect(runCli(cwd, [`disable`, `--install-directory=${npath.fromPortablePath(cwd)}`, `yarn`])).resolves.toMatchObject({
         exitCode: 0,
+        stdout: ``,
+        stderr: ``,
       });
 
       for (const variant of getBinaryNames(`yarn`))
@@ -109,7 +111,7 @@ describe(`DisableCommand`, () => {
 
       await expect(runCli(cwd, [`disable`, `--install-directory=${npath.fromPortablePath(cwd)}`])).resolves.toMatchObject({
         stdout: ``,
-        stderr: expect.stringMatching(/^yarn is already installed in .+ and points to a Yarn Switch install - skipping\n$/),
+        stderr: process.platform === `win32` ? `` : expect.stringMatching(/^yarn is already installed in .+ and points to a Yarn Switch install - skipping\n$/),
         exitCode: 0,
       });
 

--- a/tests/Disable.test.ts
+++ b/tests/Disable.test.ts
@@ -109,14 +109,18 @@ describe(`DisableCommand`, () => {
         ppath.join(cwd, `yarn`),
       );
 
+      const isWindows = process.platform === `win32`; // Yarn Switch support is Posix-only
       await expect(runCli(cwd, [`disable`, `--install-directory=${npath.fromPortablePath(cwd)}`])).resolves.toMatchObject({
         stdout: ``,
-        stderr: process.platform === `win32` ? `` : expect.stringMatching(/^yarn is already installed in .+ and points to a Yarn Switch install - skipping\n$/),
+        stderr: isWindows ? `` : expect.stringMatching(/^yarn is already installed in .+ and points to a Yarn Switch install - skipping\n$/),
         exitCode: 0,
       });
 
-      const file = await xfs.readFilePromise(ppath.join(cwd, `yarn`), `utf8`);
-      expect(file).toBe(`hello`);
+      if (isWindows) {
+        expect(xfs.existsSync(ppath.join(cwd, `yarn`))).toBe(false);
+      } else {
+        await expect(xfs.readFilePromise(ppath.join(cwd, `yarn`), `utf8`)).resolves.toBe(`hello`);
+      }
     });
   });
 });

--- a/tests/Enable.test.ts
+++ b/tests/Enable.test.ts
@@ -70,8 +70,7 @@ describe(`EnableCommand`, () => {
     await xfs.mktempPromise(async cwd => {
       const corepackBin = await makeBin(cwd, `corepack` as Filename);
 
-      process.env.PATH = `${npath.fromPortablePath(cwd)}${delimiter}${process.env.PATH}`;
-      await expect(runCli(cwd, [`enable`, `yarn`])).resolves.toMatchObject({
+      await expect(runCli(cwd, [`enable`, `--install-directory=${npath.fromPortablePath(cwd)}`, `yarn`])).resolves.toMatchObject({
         stdout: ``,
         stderr: ``,
         exitCode: 0,


### PR DESCRIPTION
When PATH lookup is disabled, it makes more sense to only have test failures for test case that specifically check for that.