### PR TITLE
fix: stop manifest search on devEngines package managers

### DIFF
--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -302,7 +302,7 @@ export class Engine {
               debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in a ${spec.name}@${spec.range} project`);
               return fallbackDescriptor;
             } else {
-              throw new UsageError(`This project is configured to use ${spec.name} because ${result.target} has a "packageManager" field`);
+              throw new UsageError(`This project is configured to use ${spec.name} because ${result.target} has a "${result.sourceField}" field`);
             }
           } else {
             debugUtils.log(`Using ${spec.name}@${spec.range} as defined in project manifest ${result.target}`);

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -229,19 +229,20 @@ export class Engine {
   }
 
   /**
-   * Locates the active project's package manager specification.
+   * Locates the package manager specification from nearest package.json having one.
    *
    * If the specification exists but doesn't match the active package manager,
    * an error is thrown to prevent users from using the wrong package manager,
    * which would lead to inconsistent project layouts.
    *
-   * If the project doesn't include a specification file, we just assume that
-   * whatever the user uses is exactly what they want to use. Since the version
-   * isn't specified, we fallback on known good versions.
+   * If none of the package.json files have specification,
+   * or a package.json had specification which was invalid but allowed failure,
+   * we just assume that whatever the user uses is exactly what they want to use.
+   * Since the version isn't specified, we fallback on known good versions.
    *
-   * Finally, if the project doesn't exist at all, we ask the user whether they
-   * want to create one in the current project. If they do, we initialize a new
-   * project using the default package managers, and configure it so that we
+   * Finally, if the package.json doesn't exist at all, we ask the user whether they
+   * want to create one in the current working directory. If they do, we initialize a new
+   * package.json using the default package managers, and configure it so that we
    * don't need to ask again in the future.
    */
   async findProjectSpec(initialCwd: string, locator: Locator | LazyLocator, {transparent = false, binaryVersion}: {transparent?: boolean, binaryVersion?: string | null} = {}): Promise<Descriptor> {

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -258,66 +258,66 @@ export class Engine {
     if (process.env.COREPACK_ENABLE_STRICT === `0`)
       transparent = true;
 
-    while (true) {
-      const result = await specUtils.loadSpec(initialCwd);
+    const result = await specUtils.loadSpec(initialCwd);
 
-      switch (result.type) {
-        case `NoProject`: {
-          if (typeof locator.reference === `function`)
-            fallbackDescriptor.range = await locator.reference();
+    switch (result.type) {
+      case `NoProject`: {
+        if (typeof locator.reference === `function`)
+          fallbackDescriptor.range = await locator.reference();
 
-          debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} as no project manifest were found`);
-          return fallbackDescriptor;
+        debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} as no project manifest were found`);
+        return fallbackDescriptor;
+      }
+
+      case `NoSpec`: {
+        if (typeof locator.reference === `function`)
+          fallbackDescriptor.range = await locator.reference();
+
+        if (process.env.COREPACK_ENABLE_AUTO_PIN === `1`) {
+          const resolved = await this.resolveDescriptor(fallbackDescriptor, {allowTags: true});
+          if (resolved === null)
+            throw new UsageError(`Failed to successfully resolve '${fallbackDescriptor.range}' to a valid ${fallbackDescriptor.name} release`);
+
+          const installSpec = await this.ensurePackageManager(resolved);
+
+          console.error(`! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing ${installSpec.locator.name}@${installSpec.locator.reference}.`);
+          console.error(`! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager`);
+          console.error();
+
+          await specUtils.setLocalPackageManager(path.dirname(result.target), installSpec);
         }
 
-        case `NoSpec`: {
-          if (typeof locator.reference === `function`)
-            fallbackDescriptor.range = await locator.reference();
+        debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in the absence of "packageManager" field in ${result.target}`);
+        return fallbackDescriptor;
+      }
 
-          if (process.env.COREPACK_ENABLE_AUTO_PIN === `1`) {
-            const resolved = await this.resolveDescriptor(fallbackDescriptor, {allowTags: true});
-            if (resolved === null)
-              throw new UsageError(`Failed to successfully resolve '${fallbackDescriptor.range}' to a valid ${fallbackDescriptor.name} release`);
+      case `Found`: {
+        const spec = result.getSpec({enforceExactVersion: !binaryVersion});
+        if (spec.name !== locator.name) {
+          const devEnginesSayMismatchIsNotError = result.sourceField === `devEngines.packageManager`
+            && result.devEnginesRange !== undefined
+            && result.devEnginesRange.onFail !== `error`;
 
-            const installSpec = await this.ensurePackageManager(resolved);
+          if (transparent || devEnginesSayMismatchIsNotError) {
+            if (typeof locator.reference === `function`)
+              fallbackDescriptor.range = await locator.reference();
 
-            console.error(`! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing ${installSpec.locator.name}@${installSpec.locator.reference}.`);
-            console.error(`! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager`);
-            console.error();
+            if (devEnginesSayMismatchIsNotError && result.devEnginesRange!.onFail === `warn`)
+              console.warn(`! Corepack validation warning: Using ${fallbackDescriptor.name} as requested (@${fallbackDescriptor.range}) because ${result.target} defines "devEngines.packageManager" with mismatched ${spec.name}@${spec.range} and onFail: warn.`);
 
-            await specUtils.setLocalPackageManager(path.dirname(result.target), installSpec);
-          }
-
-          debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in the absence of "packageManager" field in ${result.target}`);
-          return fallbackDescriptor;
-        }
-
-        case `Found`: {
-          const spec = result.getSpec({enforceExactVersion: !binaryVersion});
-          if (spec.name !== locator.name) {
-            const devEnginesSayMismatchIsNotError = result.sourceField === `devEngines.packageManager`
-              && result.devEnginesRange !== undefined
-              && result.devEnginesRange.onFail !== `error`;
-
-            if (transparent || devEnginesSayMismatchIsNotError) {
-              if (typeof locator.reference === `function`)
-                fallbackDescriptor.range = await locator.reference();
-
-              if (devEnginesSayMismatchIsNotError && result.devEnginesRange!.onFail === `warn`)
-                console.warn(`! Corepack validation warning: Using ${fallbackDescriptor.name} as requested (@${fallbackDescriptor.range}) because ${result.target} defines "devEngines.packageManager" with mismatched ${spec.name}@${spec.range} and onFail: warn.`);
-
-              debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in a ${spec.name}@${spec.range} project`);
-              return fallbackDescriptor;
-            } else {
-              throw new UsageError(`This project is configured to use ${spec.name} because ${result.target} has a "${result.sourceField}" field`);
-            }
+            debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in a ${spec.name}@${spec.range} project`);
+            return fallbackDescriptor;
           } else {
-            debugUtils.log(`Using ${spec.name}@${spec.range} as defined in project manifest ${result.target}`);
-            return spec;
+            throw new UsageError(`This project is configured to use ${spec.name} because ${result.target} has a "${result.sourceField}" field`);
           }
+        } else {
+          debugUtils.log(`Using ${spec.name}@${spec.range} as defined in project manifest ${result.target}`);
+          return spec;
         }
       }
     }
+
+    throw new Error(`Assertion failed: Unsupported loadSpec result type`);
   }
 
   async executePackageManagerRequest({packageManager, binaryName, binaryVersion}: PackageManagerRequest, {cwd, args}: {cwd: string, args: Array<string>}): Promise<void> {

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -240,10 +240,9 @@ export class Engine {
    * we just assume that whatever the user uses is exactly what they want to use.
    * Since the version isn't specified, we fallback on known good versions.
    *
-   * Finally, if the package.json doesn't exist at all, we ask the user whether they
-   * want to create one in the current working directory. If they do, we initialize a new
-   * package.json using the default package managers, and configure it so that we
-   * don't need to ask again in the future.
+   * Finally, if the package.json doesn't exist at all,
+   * we just assume that whatever the user uses is exactly what they want to use.
+   * Since the version isn't specified, we fallback on known good versions.
    */
   async findProjectSpec(initialCwd: string, locator: Locator | LazyLocator, {transparent = false, binaryVersion}: {transparent?: boolean, binaryVersion?: string | null} = {}): Promise<Descriptor> {
     // A locator is a valid descriptor (but not the other way around)

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -295,9 +295,16 @@ export class Engine {
         case `Found`: {
           const spec = result.getSpec({enforceExactVersion: !binaryVersion});
           if (spec.name !== locator.name) {
-            if (transparent) {
+            const devEnginesSayMismatchIsNotError = result.sourceField === `devEngines.packageManager`
+              && result.devEnginesRange !== undefined
+              && result.devEnginesRange.onFail !== `error`;
+
+            if (transparent || devEnginesSayMismatchIsNotError) {
               if (typeof locator.reference === `function`)
                 fallbackDescriptor.range = await locator.reference();
+
+              if (devEnginesSayMismatchIsNotError && result.devEnginesRange!.onFail === `warn`)
+                console.warn(`! Corepack validation warning: Using ${fallbackDescriptor.name} as requested (@${fallbackDescriptor.range}) because ${result.target} defines "devEngines.packageManager" with mismatched ${spec.name}@${spec.range} and onFail: warn.`);
 
               debugUtils.log(`Falling back to ${fallbackDescriptor.name}@${fallbackDescriptor.range} in a ${spec.name}@${spec.range} project`);
               return fallbackDescriptor;

--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -19,7 +19,7 @@ export abstract class BaseCommand extends Command<Context> {
           throw new UsageError(`The local project doesn't feature a 'packageManager' field nor a 'devEngines.packageManager' field - please specify the package manager to pack, or update the manifest to reference it`);
 
         default: {
-          return [lookup.range ?? lookup.getSpec()];
+          return [lookup.devEnginesRange ?? lookup.getSpec()];
         }
       }
     }

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -106,11 +106,15 @@ function warnOrThrow(errorMessage: string, onFail?: DevEngineDependency[`onFail`
 }
 function parsePackageJSON(packageJSONContent: CorepackPackageJSON): ParsedPackageManager | undefined {
   const {packageManager: pm} = packageJSONContent;
-  const resultFromPackageManager = pm
+
+  const resultFromPackageManager = pm !== undefined
     ? {sourceField: `packageManager`, rawPmSpec: pm} satisfies ParsedPackageManager
     : undefined;
 
-  if (packageJSONContent.devEngines?.packageManager) {
+  if (pm === `` || pm === null)
+    return resultFromPackageManager; // short-circuit with defined, but invalid "packageManager" values
+
+  if (packageJSONContent.devEngines?.packageManager !== undefined) {
     const {packageManager} = packageJSONContent.devEngines;
 
     if (typeof packageManager !== `object`) {
@@ -134,7 +138,7 @@ function parsePackageJSON(packageJSONContent: CorepackPackageJSON): ParsedPackag
 
     debugUtils.log(`devEngines.packageManager defines that ${name}@${version} is the local package manager`);
 
-    if (pm) {
+    if (pm !== undefined) {
       if (!pm.startsWith?.(`${name}@`))
         warnOrThrow(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the "devEngines.packageManager" field set to ${JSON.stringify(name)}`, onFail);
 
@@ -196,6 +200,13 @@ export type LoadSpecResult =
     | {type: `NoSpec`, target: string}
     | FoundSpecResult;
 
+// We walk up the directory tree to support workspace-style projects whose
+// package manager may be declared in a higher-level manifest. The search
+// stops at the nearest package.json that defines either package manager
+// field, even if that value is invalid. The tradeoff is that if the nearest
+// package.json does not define any package manager field, then an upper-level
+// package.json can dictate which package manager gets used even when that
+// higher-level manifest is unrelated to the current project.
 export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
   let nextCwd = initialCwd;
   let currCwd = ``;
@@ -208,7 +219,7 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
   } | null = null;
 
   const selectionHasPmSpecified = (selection: {data: CorepackPackageJSON} | null) => {
-    return selection !== null && (selection.data.packageManager || selection.data.devEngines?.packageManager);
+    return selection !== null && (selection.data.packageManager !== undefined || selection.data.devEngines?.packageManager !== undefined);
   };
 
   while (nextCwd !== currCwd && !selectionHasPmSpecified(selection)) {

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -127,18 +127,18 @@ function parsePackageJSON(packageJSONContent: CorepackPackageJSON): ParsedPackag
   if (packageJSONContent.devEngines?.packageManager === undefined)
     return resultFromPackageManager;
 
-  const {packageManager: packageManager} = packageJSONContent.devEngines;
+  const {packageManager: devEnginesPackageManager} = packageJSONContent.devEngines;
 
-  if (typeof packageManager !== `object`) {
-    console.warn(`! Corepack only supports objects as valid value for devEngines.packageManager. The current value (${JSON.stringify(packageManager)}) will be ignored.`);
+  if (typeof devEnginesPackageManager !== `object`) {
+    console.warn(`! Corepack only supports objects as valid value for devEngines.packageManager. The current value (${JSON.stringify(devEnginesPackageManager)}) will be ignored.`);
     return resultFromPackageManager;
   }
-  if (Array.isArray(packageManager)) {
+  if (Array.isArray(devEnginesPackageManager)) {
     console.warn(`! Corepack does not currently support array values for devEngines.packageManager`);
     return resultFromPackageManager;
   }
 
-  const {name, version, onFail} = packageManager;
+  const {name, version, onFail} = devEnginesPackageManager;
   if (typeof name !== `string` || name.includes(`@`)) {
     warnOrThrow(`The value of devEngines.packageManager.name ${JSON.stringify(name)} is not a supported string value`, onFail);
     return resultFromPackageManager;
@@ -154,19 +154,19 @@ function parsePackageJSON(packageJSONContent: CorepackPackageJSON): ParsedPackag
     if (!pm.startsWith?.(`${name}@`))
       warnOrThrow(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the "devEngines.packageManager" field set to ${JSON.stringify(name)}`, onFail);
 
-    else if (version != null && !semverSatisfies(pm.slice(packageManager.name.length + 1), version))
+    else if (version != null && !semverSatisfies(pm.slice(devEnginesPackageManager.name.length + 1), version))
       warnOrThrow(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the value defined in "devEngines.packageManager" for ${JSON.stringify(name)} of ${JSON.stringify(version)}`, onFail);
 
     return {
       ...resultFromPackageManager!,
-      devEnginesValues: packageManager,
+      devEnginesValues: devEnginesPackageManager,
     };
   }
 
   return {
     sourceField: `devEngines.packageManager`,
     rawPmSpec: `${name}@${version ?? `*`}`,
-    devEnginesValues: packageManager,
+    devEnginesValues: devEnginesPackageManager,
   };
 }
 

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -124,50 +124,50 @@ function parsePackageJSON(packageJSONContent: CorepackPackageJSON): ParsedPackag
   if (pm === `` || pm === null)
     return resultFromPackageManager; // short-circuit with defined, but invalid "packageManager" values
 
-  if (packageJSONContent.devEngines?.packageManager !== undefined) {
-    const {packageManager} = packageJSONContent.devEngines;
+  if (packageJSONContent.devEngines?.packageManager === undefined)
+    return resultFromPackageManager;
 
-    if (typeof packageManager !== `object`) {
-      console.warn(`! Corepack only supports objects as valid value for devEngines.packageManager. The current value (${JSON.stringify(packageManager)}) will be ignored.`);
-      return resultFromPackageManager;
-    }
-    if (Array.isArray(packageManager)) {
-      console.warn(`! Corepack does not currently support array values for devEngines.packageManager`);
-      return resultFromPackageManager;
-    }
+  const {packageManager: packageManager} = packageJSONContent.devEngines;
 
-    const {name, version, onFail} = packageManager;
-    if (typeof name !== `string` || name.includes(`@`)) {
-      warnOrThrow(`The value of devEngines.packageManager.name ${JSON.stringify(name)} is not a supported string value`, onFail);
-      return resultFromPackageManager;
-    }
-    if (version != null && (typeof version !== `string` || !semverValidRange(version))) {
-      warnOrThrow(`The value of devEngines.packageManager.version ${JSON.stringify(version)} is not a valid semver range`, onFail);
-      return resultFromPackageManager;
-    }
+  if (typeof packageManager !== `object`) {
+    console.warn(`! Corepack only supports objects as valid value for devEngines.packageManager. The current value (${JSON.stringify(packageManager)}) will be ignored.`);
+    return resultFromPackageManager;
+  }
+  if (Array.isArray(packageManager)) {
+    console.warn(`! Corepack does not currently support array values for devEngines.packageManager`);
+    return resultFromPackageManager;
+  }
 
-    debugUtils.log(`devEngines.packageManager defines that ${name}@${version} is the local package manager`);
+  const {name, version, onFail} = packageManager;
+  if (typeof name !== `string` || name.includes(`@`)) {
+    warnOrThrow(`The value of devEngines.packageManager.name ${JSON.stringify(name)} is not a supported string value`, onFail);
+    return resultFromPackageManager;
+  }
+  if (version != null && (typeof version !== `string` || !semverValidRange(version))) {
+    warnOrThrow(`The value of devEngines.packageManager.version ${JSON.stringify(version)} is not a valid semver range`, onFail);
+    return resultFromPackageManager;
+  }
 
-    if (pm !== undefined) {
-      if (!pm.startsWith?.(`${name}@`))
-        warnOrThrow(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the "devEngines.packageManager" field set to ${JSON.stringify(name)}`, onFail);
+  debugUtils.log(`devEngines.packageManager defines that ${name}@${version} is the local package manager`);
 
-      else if (version != null && !semverSatisfies(pm.slice(packageManager.name.length + 1), version))
-        warnOrThrow(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the value defined in "devEngines.packageManager" for ${JSON.stringify(name)} of ${JSON.stringify(version)}`, onFail);
+  if (pm !== undefined) {
+    if (!pm.startsWith?.(`${name}@`))
+      warnOrThrow(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the "devEngines.packageManager" field set to ${JSON.stringify(name)}`, onFail);
 
-      return {
-        ...resultFromPackageManager!,
-        devEnginesValues: packageManager,
-      };
-    }
+    else if (version != null && !semverSatisfies(pm.slice(packageManager.name.length + 1), version))
+      warnOrThrow(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the value defined in "devEngines.packageManager" for ${JSON.stringify(name)} of ${JSON.stringify(version)}`, onFail);
+
     return {
-      sourceField: `devEngines.packageManager`,
-      rawPmSpec: `${name}@${version ?? `*`}`,
+      ...resultFromPackageManager!,
       devEnginesValues: packageManager,
     };
   }
 
-  return resultFromPackageManager;
+  return {
+    sourceField: `devEngines.packageManager`,
+    rawPmSpec: `${name}@${version ?? `*`}`,
+    devEnginesValues: packageManager,
+  };
 }
 
 export async function setLocalPackageManager(cwd: string, info: PreparedPackageManagerInfo) {

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -91,14 +91,24 @@ type ParsedPackageManager = {
 interface DevEngineDependency {
   name: string;
   version: string;
-  onFail?: `ignore` | `warn` | `error`;
+  onFail?: `ignore` | `warn` | `error` | `download`;
 }
-function warnOrThrow(errorMessage: string, onFail?: DevEngineDependency[`onFail`]) {
+
+function normalizeOnFail(onFail?: DevEngineDependency[`onFail`]) {
   switch (onFail) {
+    case undefined:
+    case `download`:
+      return `error`;
+    default:
+      return onFail;
+  }
+}
+
+function warnOrThrow(errorMessage: string, onFail?: DevEngineDependency[`onFail`]) {
+  switch (normalizeOnFail(onFail)) {
     case `ignore`:
       break;
     case `error`:
-    case undefined:
       throw new UsageError(errorMessage);
     default:
       console.warn(`! Corepack validation warning: ${errorMessage}`);
@@ -193,7 +203,7 @@ interface FoundSpecResult {
   getSpec: (options?: {enforceExactVersion?: boolean}) => Descriptor;
   envFilePath?: string;
   sourceField: PackageManagerSourceField; // source of the spec
-  devEnginesRange?: Descriptor & {onFail: Required<DevEngineDependency>[`onFail`]};
+  devEnginesRange?: Descriptor & {onFail: `ignore` | `warn` | `error`};
 }
 export type LoadSpecResult =
     | {type: `NoProject`, target: string}
@@ -299,7 +309,7 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
     devEnginesRange: parsedPackageManager.devEnginesValues && {
       name: parsedPackageManager.devEnginesValues.name,
       range: parsedPackageManager.devEnginesValues.version,
-      onFail: parsedPackageManager.devEnginesValues.onFail ?? `error`,
+      onFail: normalizeOnFail(parsedPackageManager.devEnginesValues.onFail),
     },
     // Lazy-loading it so we do not throw errors on commands that do not need valid spec.
     getSpec: ({enforceExactVersion = true} = {}) => parseSpec(parsedPackageManager, path.relative(initialCwd, selection.manifestPath), {enforceExactVersion}),

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -15,19 +15,32 @@ import type {LocalEnvFile}                     from './types';
 
 const nodeModulesRegExp = /[\\/]node_modules[\\/](@[^\\/]*[\\/])?([^@\\/][^\\/]*)$/;
 
-export function parseSpec(raw: unknown, source: string, {enforceExactVersion = true} = {}): Descriptor {
+export function parseSpec(arg: string | ParsedPackageManager, source: string, {enforceExactVersion = true} = {}): Descriptor {
+  let raw: string;
+  let sourceField: PackageManagerSourceField | undefined;
+
+  if (typeof arg === `object` && arg.sourceField !== undefined) {
+    raw = arg.rawPmSpec;
+    sourceField = arg.sourceField;
+  } else {
+    raw = arg as string;
+    sourceField = undefined;
+  }
+
+  const maybeSourceFieldOf = sourceField ? `"${sourceField}" of ` : ``;
+
   if (typeof raw !== `string`)
-    throw new UsageError(`Invalid package manager specification in ${source}; expected a string`);
+    throw new UsageError(`Invalid package manager specification in ${maybeSourceFieldOf}${source}; expected a string`);
 
   const atIndex = raw.indexOf(`@`);
 
   if (atIndex === -1 || atIndex === raw.length - 1) {
     if (enforceExactVersion)
-      throw new UsageError(`No version specified for ${raw} in "packageManager" of ${source}`);
+      throw new UsageError(`No version specified for ${raw} in ${maybeSourceFieldOf}${source}`);
 
     const name = atIndex === -1 ? raw : raw.slice(0, -1);
     if (!isSupportedPackageManager(name))
-      throw new UsageError(`Unsupported package manager specification (${name})`);
+      throw new UsageError(`Unsupported package manager specification (${name}) in ${maybeSourceFieldOf}${source}`);
 
     return {
       name, range: `*`,
@@ -40,13 +53,13 @@ export function parseSpec(raw: unknown, source: string, {enforceExactVersion = t
   const isURL = URL.canParse(range);
   if (!isURL) {
     if (enforceExactVersion && !semverValid(range))
-      throw new UsageError(`Invalid package manager specification in ${source} (${raw}); expected a semver version${enforceExactVersion ? `` : `, range, or tag`}`);
+      throw new UsageError(`Invalid package manager specification in ${maybeSourceFieldOf}${source} (${raw}); expected a semver version${enforceExactVersion ? `` : `, range, or tag`}`);
 
     if (!isSupportedPackageManager(name)) {
-      throw new UsageError(`Unsupported package manager specification (${raw})`);
+      throw new UsageError(`Unsupported package manager specification (${raw}) in ${maybeSourceFieldOf}${source}`);
     }
   } else if (isSupportedPackageManager(name) && process.env.COREPACK_ENABLE_UNSAFE_CUSTOM_URLS !== `1`) {
-    throw new UsageError(`Illegal use of URL for known package manager. Instead, select a specific version, or set COREPACK_ENABLE_UNSAFE_CUSTOM_URLS=1 in your environment (${raw})`);
+    throw new UsageError(`Illegal use of URL for known package manager. Instead, select a specific version, or set COREPACK_ENABLE_UNSAFE_CUSTOM_URLS=1 in your environment (${raw}) in ${maybeSourceFieldOf}${source}`);
   }
 
 
@@ -60,6 +73,20 @@ type CorepackPackageJSON = {
   packageManager?: string;
   devEngines?: {packageManager?: DevEngineDependency};
 };
+
+type PackageManagerSourceField = `packageManager` | `devEngines.packageManager`;
+
+type ParsedPackageManager = {
+  sourceField: PackageManagerSourceField;
+  rawPmSpec: string;
+  devEnginesValues?: DevEngineDependency;
+} & ({
+  sourceField: `packageManager`;
+} | {
+  sourceField: `devEngines.packageManager`;
+  devEnginesValues: DevEngineDependency;
+}
+);
 
 interface DevEngineDependency {
   name: string;
@@ -77,28 +104,32 @@ function warnOrThrow(errorMessage: string, onFail?: DevEngineDependency[`onFail`
       console.warn(`! Corepack validation warning: ${errorMessage}`);
   }
 }
-function parsePackageJSON(packageJSONContent: CorepackPackageJSON) {
+function parsePackageJSON(packageJSONContent: CorepackPackageJSON): ParsedPackageManager | undefined {
   const {packageManager: pm} = packageJSONContent;
-  if (packageJSONContent.devEngines?.packageManager != null) {
+  const resultFromPackageManager = pm
+    ? {sourceField: `packageManager`, rawPmSpec: pm} satisfies ParsedPackageManager
+    : undefined;
+
+  if (packageJSONContent.devEngines?.packageManager) {
     const {packageManager} = packageJSONContent.devEngines;
 
     if (typeof packageManager !== `object`) {
       console.warn(`! Corepack only supports objects as valid value for devEngines.packageManager. The current value (${JSON.stringify(packageManager)}) will be ignored.`);
-      return pm;
+      return resultFromPackageManager;
     }
     if (Array.isArray(packageManager)) {
       console.warn(`! Corepack does not currently support array values for devEngines.packageManager`);
-      return pm;
+      return resultFromPackageManager;
     }
 
     const {name, version, onFail} = packageManager;
     if (typeof name !== `string` || name.includes(`@`)) {
       warnOrThrow(`The value of devEngines.packageManager.name ${JSON.stringify(name)} is not a supported string value`, onFail);
-      return pm;
+      return resultFromPackageManager;
     }
     if (version != null && (typeof version !== `string` || !semverValidRange(version))) {
       warnOrThrow(`The value of devEngines.packageManager.version ${JSON.stringify(version)} is not a valid semver range`, onFail);
-      return pm;
+      return resultFromPackageManager;
     }
 
     debugUtils.log(`devEngines.packageManager defines that ${name}@${version} is the local package manager`);
@@ -110,20 +141,25 @@ function parsePackageJSON(packageJSONContent: CorepackPackageJSON) {
       else if (version != null && !semverSatisfies(pm.slice(packageManager.name.length + 1), version))
         warnOrThrow(`"packageManager" field is set to ${JSON.stringify(pm)} which does not match the value defined in "devEngines.packageManager" for ${JSON.stringify(name)} of ${JSON.stringify(version)}`, onFail);
 
-      return pm;
+      return {
+        ...resultFromPackageManager!,
+        devEnginesValues: packageManager,
+      };
     }
-
-
-    return `${name}@${version ?? `*`}`;
+    return {
+      sourceField: `devEngines.packageManager`,
+      rawPmSpec: `${name}@${version ?? `*`}`,
+      devEnginesValues: packageManager,
+    };
   }
 
-  return pm;
+  return resultFromPackageManager;
 }
 
 export async function setLocalPackageManager(cwd: string, info: PreparedPackageManagerInfo) {
   const lookup = await loadSpec(cwd);
 
-  const range = `range` in lookup && lookup.range;
+  const range = `devEnginesRange` in lookup && lookup.devEnginesRange;
   if (range) {
     if (info.locator.name !== range.name || !semverSatisfies(info.locator.reference, range.range)) {
       warnOrThrow(`The requested version of ${info.locator.name}@${info.locator.reference} does not match the devEngines specification (${range.name}@${range.range})`, range.onFail);
@@ -151,8 +187,9 @@ interface FoundSpecResult {
   type: `Found`;
   target: string;
   getSpec: (options?: {enforceExactVersion?: boolean}) => Descriptor;
-  range?: Descriptor & {onFail?: DevEngineDependency[`onFail`]};
   envFilePath?: string;
+  sourceField: PackageManagerSourceField; // source of the spec
+  devEnginesRange?: Descriptor & {onFail: Required<DevEngineDependency>[`onFail`]};
 }
 export type LoadSpecResult =
     | {type: `NoProject`, target: string}
@@ -170,7 +207,11 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
     localEnv: LocalEnvFile;
   } | null = null;
 
-  while (nextCwd !== currCwd && (!selection || !selection.data.packageManager)) {
+  const selectionHasPmSpecified = (selection: {data: CorepackPackageJSON} | null) => {
+    return selection !== null && (selection.data.packageManager || selection.data.devEngines?.packageManager);
+  };
+
+  while (nextCwd !== currCwd && !selectionHasPmSpecified(selection)) {
     currCwd = nextCwd;
     nextCwd = path.dirname(currCwd);
 
@@ -233,22 +274,23 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
     process.env = selection.localEnv;
   }
 
-  const rawPmSpec = parsePackageJSON(selection.data);
-  if (typeof rawPmSpec === `undefined`)
+  const parsedPackageManager = parsePackageJSON(selection.data);
+  if (typeof parsedPackageManager === `undefined`)
     return {type: `NoSpec`, target: selection.manifestPath};
 
-  debugUtils.log(`${selection.manifestPath} defines ${rawPmSpec} as local package manager`);
+  debugUtils.log(`${selection.manifestPath} defines ${parsedPackageManager.rawPmSpec} as local package manager via ${parsedPackageManager.sourceField}`);
 
   return {
     type: `Found`,
     target: selection.manifestPath,
+    sourceField: parsedPackageManager.sourceField,
     envFilePath,
-    range: selection.data.devEngines?.packageManager?.version && {
-      name: selection.data.devEngines.packageManager.name,
-      range: selection.data.devEngines.packageManager.version,
-      onFail: selection.data.devEngines.packageManager.onFail,
+    devEnginesRange: parsedPackageManager.devEnginesValues && {
+      name: parsedPackageManager.devEnginesValues.name,
+      range: parsedPackageManager.devEnginesValues.version,
+      onFail: parsedPackageManager.devEnginesValues.onFail ?? `error`,
     },
     // Lazy-loading it so we do not throw errors on commands that do not need valid spec.
-    getSpec: ({enforceExactVersion = true} = {}) => parseSpec(rawPmSpec, path.relative(initialCwd, selection.manifestPath), {enforceExactVersion}),
+    getSpec: ({enforceExactVersion = true} = {}) => parseSpec(parsedPackageManager, path.relative(initialCwd, selection.manifestPath), {enforceExactVersion}),
   };
 }

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -255,7 +255,7 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
     } catch {}
 
     if (typeof data !== `object` || data === null)
-      throw new UsageError(`Invalid package.json in ${path.relative(initialCwd, manifestPath)}`);
+      throw new UsageError(`Could not parse ${path.relative(initialCwd, manifestPath)} as JSON.`);
 
     let localEnv: LocalEnvFile;
     const envFilePath = path.resolve(currCwd, process.env.COREPACK_ENV_FILE ?? `.corepack.env`);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -4,6 +4,7 @@ import process                                       from 'node:process';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
 import config                                        from '../config.json';
+import {Engine}                                      from '../sources/Engine';
 import * as folderUtils                              from '../sources/folderUtils';
 import {SupportedPackageManagerSet}                  from '../sources/types';
 
@@ -660,6 +661,94 @@ it(`should ignore a parent packageManager when a closer devEngines.packageManage
       exitCode: 0,
       stderr: expect.stringContaining(`The value of devEngines.packageManager.version "bad" is not a valid semver range`),
       stdout: `${config.definitions.npm.default.split(`+`, 1)[0]}\n`,
+    });
+  });
+});
+
+it(`should use the closest devEngines.packageManager field when parent has no spec in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
+      // empty package.json file
+    });
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+        },
+      },
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `npm`,
+      reference: `9.9.9`,
+    })).resolves.toMatchObject({
+      name: `npm`,
+      range: `6.14.2`,
+    });
+  });
+});
+
+it(`should use the closest devEngines.packageManager field over a parent packageManager in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
+      packageManager: `yarn@1.22.4`,
+    });
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+        },
+      },
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `npm`,
+      reference: `9.9.9`,
+    })).resolves.toMatchObject({
+      name: `npm`,
+      range: `6.14.2`,
+    });
+  });
+});
+
+it(`should ignore a parent packageManager when a closer devEngines.packageManager is invalid with onFail set to "warn" in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
+      packageManager: `yarn@1.22.4`,
+    });
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `bad`,
+          onFail: `warn`,
+        },
+      },
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `npm`,
+      reference: `9.9.9`,
+    })).resolves.toMatchObject({
+      name: `npm`,
+      range: `9.9.9`,
     });
   });
 });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,14 +1,14 @@
-import {Filename, ppath, xfs, npath, PortablePath}   from '@yarnpkg/fslib';
-import os                                            from 'node:os';
-import process                                       from 'node:process';
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {Filename, ppath, xfs, npath, PortablePath}       from '@yarnpkg/fslib';
+import os                                                from 'node:os';
+import process                                           from 'node:process';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
-import config                                        from '../config.json';
-import {Engine}                                      from '../sources/Engine';
-import * as folderUtils                              from '../sources/folderUtils';
-import {SupportedPackageManagerSet}                  from '../sources/types';
+import config                                            from '../config.json';
+import {Engine}                                          from '../sources/Engine';
+import * as folderUtils                                  from '../sources/folderUtils';
+import {SupportedPackageManagerSet}                      from '../sources/types';
 
-import {runCli}                                      from './_runCli';
+import {runCli}                                          from './_runCli';
 
 
 beforeEach(async () => {
@@ -709,6 +709,92 @@ it(`should mention devEngines.packageManager when Engine.findProjectSpec rejects
         packageManager: {
           name: `npm`,
           version: `6.14.2`,
+        },
+      },
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `yarn`,
+      reference: `1.22.4`,
+    })).rejects.toThrow(`This project is configured to use npm because ${npath.fromPortablePath(ppath.join(projectCwd, `package.json` as Filename))} has a "devEngines.packageManager" field`);
+  });
+});
+
+it(`should fall back to the requested package manager when only devEngines.packageManager mismatches with onFail set to "ignore" in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+          onFail: `ignore`,
+        },
+      },
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `yarn`,
+      reference: `1.22.4`,
+    })).resolves.toMatchObject({
+      name: `yarn`,
+      range: `1.22.4`,
+    });
+  });
+});
+
+it(`should fall back to the requested package manager and warn when only devEngines.packageManager mismatches with onFail set to "warn" in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+          onFail: `warn`,
+        },
+      },
+    });
+
+    const warn = vi.spyOn(console, `warn`).mockImplementation(() => {});
+
+    try {
+      const engine = new Engine();
+      await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+        name: `yarn`,
+        reference: `1.22.4`,
+      })).resolves.toMatchObject({
+        name: `yarn`,
+        range: `1.22.4`,
+      });
+
+      expect(warn).toHaveBeenCalledWith(`! Corepack validation warning: Using yarn as requested (@1.22.4) because ${npath.fromPortablePath(ppath.join(projectCwd, `package.json` as Filename))} defines "devEngines.packageManager" with mismatched npm@6.14.2 and onFail: warn.`);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+it(`should reject when only devEngines.packageManager mismatches with onFail set to "download" in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+          onFail: `download`,
         },
       },
     });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -582,6 +582,88 @@ it(`should use the closest matching packageManager field`, async () => {
   });
 });
 
+it(`should use the closest matching devEngines.packageManager field when parent has no spec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as PortablePath), {
+      // empty package.json file
+    });
+
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as PortablePath), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+        },
+      },
+    });
+
+    await expect(runCli(projectCwd, [`npm`, `--version`])).resolves.toMatchObject({
+      exitCode: 0,
+      stderr: ``,
+      stdout: `6.14.2\n`,
+    });
+  });
+});
+
+it(`should use the closest matching devEngines.packageManager field over a parent packageManager field`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as PortablePath), {
+      packageManager: `yarn@1.22.4`,
+    });
+
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as PortablePath), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+        },
+      },
+    });
+
+    await expect(runCli(projectCwd, [`npm`, `--version`])).resolves.toMatchObject({
+      exitCode: 0,
+      stderr: ``,
+      stdout: `6.14.2\n`,
+    });
+  });
+});
+
+it(`should ignore a parent packageManager when a closer devEngines.packageManager is invalid but non-fatal`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as PortablePath), {
+      packageManager: `yarn@1.22.4`,
+    });
+
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as PortablePath), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `bad`,
+          onFail: `warn`,
+        },
+      },
+    });
+
+    await expect(runCli(projectCwd, [`npm`, `--version`])).resolves.toMatchObject({
+      exitCode: 0,
+      stderr: expect.stringContaining(`The value of devEngines.packageManager.version "bad" is not a valid semver range`),
+      stdout: `${config.definitions.npm.default.split(`+`, 1)[0]}\n`,
+    });
+  });
+});
+
 it(`should expose its root to spawned processes`, async () => {
   await xfs.mktempPromise(async cwd => {
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -776,6 +776,96 @@ it(`should mention devEngines.packageManager when Engine.findProjectSpec rejects
   });
 });
 
+it(`should treat packageManager empty string as an invalid selected value in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      packageManager: ``,
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+        },
+      },
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `npm`,
+      reference: `9.9.9`,
+    })).rejects.toThrow(`No version specified for  in "packageManager" of package.json`);
+  });
+});
+
+it(`should stop at a child packageManager empty string instead of falling back to a parent manifest in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
+      packageManager: `yarn@1.22.4`,
+    });
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      packageManager: ``,
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `yarn`,
+      reference: `1.22.4`,
+    })).rejects.toThrow(`No version specified for  in "packageManager" of package.json`);
+  });
+});
+
+it(`should treat packageManager null as an invalid selected value in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      packageManager: null,
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+        },
+      },
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `npm`,
+      reference: `9.9.9`,
+    })).rejects.toThrow(`Invalid package manager specification in "packageManager" of package.json; expected a string`);
+  });
+});
+
+it(`should stop at a child packageManager null instead of falling back to a parent manifest in Engine.findProjectSpec`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {
+      packageManager: `yarn@1.22.4`,
+    });
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      packageManager: null,
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `yarn`,
+      reference: `1.22.4`,
+    })).rejects.toThrow(`Invalid package manager specification in "packageManager" of package.json; expected a string`);
+  });
+});
+
 it(`should expose its root to spawned processes`, async () => {
   await xfs.mktempPromise(async cwd => {
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -583,33 +583,6 @@ it(`should use the closest matching packageManager field`, async () => {
   });
 });
 
-it(`should use the closest matching devEngines.packageManager field when parent has no spec`, async () => {
-  await xfs.mktempPromise(async cwd => {
-    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
-
-    await xfs.mkdirPromise(projectCwd, {recursive: true});
-
-    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as PortablePath), {
-      // empty package.json file
-    });
-
-    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as PortablePath), {
-      devEngines: {
-        packageManager: {
-          name: `npm`,
-          version: `6.14.2`,
-        },
-      },
-    });
-
-    await expect(runCli(projectCwd, [`npm`, `--version`])).resolves.toMatchObject({
-      exitCode: 0,
-      stderr: ``,
-      stdout: `6.14.2\n`,
-    });
-  });
-});
-
 it(`should use the closest matching devEngines.packageManager field over a parent packageManager field`, async () => {
   await xfs.mktempPromise(async cwd => {
     const projectCwd = ppath.join(cwd, `foo` as PortablePath);
@@ -633,34 +606,6 @@ it(`should use the closest matching devEngines.packageManager field over a paren
       exitCode: 0,
       stderr: ``,
       stdout: `6.14.2\n`,
-    });
-  });
-});
-
-it(`should ignore a parent packageManager when a closer devEngines.packageManager is invalid but non-fatal`, async () => {
-  await xfs.mktempPromise(async cwd => {
-    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
-
-    await xfs.mkdirPromise(projectCwd, {recursive: true});
-
-    await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as PortablePath), {
-      packageManager: `yarn@1.22.4`,
-    });
-
-    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as PortablePath), {
-      devEngines: {
-        packageManager: {
-          name: `npm`,
-          version: `bad`,
-          onFail: `warn`,
-        },
-      },
-    });
-
-    await expect(runCli(projectCwd, [`npm`, `--version`])).resolves.toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining(`The value of devEngines.packageManager.version "bad" is not a valid semver range`),
-      stdout: `${config.definitions.npm.default.split(`+`, 1)[0]}\n`,
     });
   });
 });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -753,6 +753,29 @@ it(`should ignore a parent packageManager when a closer devEngines.packageManage
   });
 });
 
+it(`should mention devEngines.packageManager when Engine.findProjectSpec rejects a mismatched package manager`, async () => {
+  await xfs.mktempPromise(async cwd => {
+    const projectCwd = ppath.join(cwd, `foo` as PortablePath);
+
+    await xfs.mkdirPromise(projectCwd, {recursive: true});
+
+    await xfs.writeJsonPromise(ppath.join(projectCwd, `package.json` as Filename), {
+      devEngines: {
+        packageManager: {
+          name: `npm`,
+          version: `6.14.2`,
+        },
+      },
+    });
+
+    const engine = new Engine();
+    await expect(engine.findProjectSpec(npath.fromPortablePath(projectCwd), {
+      name: `yarn`,
+      reference: `1.22.4`,
+    })).rejects.toThrow(`This project is configured to use npm because ${npath.fromPortablePath(ppath.join(projectCwd, `package.json` as Filename))} has a "devEngines.packageManager" field`);
+  });
+});
+
 it(`should expose its root to spawned processes`, async () => {
   await xfs.mktempPromise(async cwd => {
     await xfs.writeJsonPromise(ppath.join(cwd, `package.json` as Filename), {


### PR DESCRIPTION
fixes #779 

**Summary**

This branch is intentionally a small stack, not a single behavioral change.

The main fix is the manifest-selection bug from #779: when scanning parent directories, `loadSpec` now stops at the nearest `package.json` that defines either `packageManager` or `devEngines.packageManager`. Before that, the scan only stopped for `packageManager`, so a closer manifest using only `devEngines.packageManager` could be skipped and a parent manifest could win instead.

The branch then adds two explicit follow-up behavior changes that became clearer while fixing the lookup:

- top-level `packageManager: ""` and `packageManager: null` are now treated as defined but invalid values of the nearest manifest, so lookup stops there and reports an invalid `"packageManager"` instead of treating those values as absent and falling through to a parent `package.json`
- `Engine.findProjectSpec` now honors non-error `onFail` for package-manager name mismatches when the selected project package manager comes only from `devEngines.packageManager`; in those cases, `onFail: warn` / `ignore` can fall back to the requested package manager instead of throwing

The branch also improves invalid `"packageManager"` errors so they mention which field in the selected `package.json` was used.

**Decision table**

The table below describes the outcome for the nearest selected manifest. It intentionally ignores transparent-command behavior, which can still choose fallback for separate reasons.

| packageManager | devEngines.packageManager | Effective onFail | Selected-manifest result                     | Engine.findProjectSpec result                        |
| -------------- | ------------------------- | ---------------- | -------------------------------------------- | ---------------------------------------------------- |
| absent         | absent                    | n/a              | continue scanning upward                     | if nothing else is found: NoSpec -> use fallback     |
| valid          | absent                    | n/a              | stop and use packageManager                  | enforce that package manager                         |
| invalid        | absent                    | n/a              | stop and report invalid packageManager       | throw invalid packageManager error                   |
| absent         | valid                     | error            | stop and use devEngines.packageManager       | enforce that package manager; mismatch throws        |
| absent         | valid                     | warn / ignore    | stop and use devEngines.packageManager       | mismatch falls back to requested package manager     |
| absent         | invalid                   | error            | stop and report invalid devEngines           | throw invalid devEngines.packageManager error        |
| absent         | invalid                   | warn / ignore    | stop at nearest manifest and return NoSpec   | use fallback                                         |
| valid          | valid and matching        | any              | stop and use packageManager                  | enforce packageManager                               |
| valid          | valid but mismatching     | error            | stop and report field mismatch               | throw mismatch error                                 |
| valid          | valid but mismatching     | warn / ignore    | stop and use packageManager                  | enforce packageManager                               |
| valid          | invalid                   | error            | stop and report invalid devEngines           | throw invalid devEngines.packageManager error        |
| valid          | invalid                   | warn / ignore    | stop and use packageManager                  | enforce packageManager                               |

**Tests**

- keep one CLI regression for the mixed-field case where a child `devEngines.packageManager` must win over a parent `packageManager`
- add `Engine.findProjectSpec` coverage for:
  - nearest child `devEngines.packageManager` when the parent has no package-manager field
  - nearest child `devEngines.packageManager` over a parent `packageManager`
  - nearest invalid child `devEngines.packageManager` with `onFail: warn`, which must stop the search and use fallback rather than a parent `packageManager`
  - nearest child `packageManager: ""`
  - nearest child `packageManager: null`

**Notes**

- This branch changes behavior for `packageManager: ""` and `packageManager: null`: they no longer behave like an absent field during upward lookup.
- Follow-up suggestion: `onFail` should probably not affect structurally invalid `devEngines.packageManager` definitions, for example when `name` is not a string or `version` is not a valid semver range. Those look like malformed configuration rather than mismatch-policy choices, so they likely should always throw. The mismatch cases can still remain controlled by `onFail`.

**Commit ordering**

- the first two commits are pure repros, so reviewers can inspect the failing scenarios before reading the fix
- the next functional commits are ordered from root cause to follow-up semantics: first nearest-manifest selection, then explicit `packageManager: "" | null` handling, then the `onFail: warn` fallback behavior, then the error-path improvement
- the CLI coverage reduction is kept as its own test-shaping commit so the single retained end-to-end repro stays obvious
- the final docs and refactor commits are intentionally last, so reviewers can read behavioral changes without rename / comment / control-flow cleanup noise mixed into them