### PR TITLE
chore(ci): update gr2m/create-or-update-pull-request-action to v1.10.1

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -49,7 +49,7 @@ jobs:
             },
           }" > config.json
 
-      - uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5 # v1.9.2
+      - uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b # v1.10.1
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.
         env:


### PR DESCRIPTION
## Situation

The [.github/workflows/sync.yml](https://github.com/nodejs/corepack/blob/main/.github/workflows/sync.yml) workflow is using an outdated version of the GitHub Action [gr2m/create-or-update-pull-request-action](https://github.com/gr2m/create-or-update-pull-request-action)

```yml
- uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5 # v1.9.2
```

The SHA https://github.com/gr2m/create-or-update-pull-request-action/commit/77596e3166f328b24613f7082ab30bf2d93079d5, is not linked to any [release](https://github.com/gr2m/create-or-update-pull-request-action/releases) or [tags](https://github.com/gr2m/create-or-update-pull-request-action/tags). This appears to be causing Dependabot updates to fail for ALL `github-actions`.

## Change

Update [.github/workflows/sync.yml](https://github.com/nodejs/corepack/blob/main/.github/workflows/sync.yml) to use:

[gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b](https://github.com/gr2m/create-or-update-pull-request-action/commit/b65137ca591da0b9f43bad7b24df13050ea45d1b) (current `latest` and equivalent to [v1.10.1](https://github.com/gr2m/create-or-update-pull-request-action/releases/tag/v1.10.1)).

