### PR TITLE
chore: migrate to nodeLinker: node-modules

### DIFF
--- a/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch
+++ b/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch
@@ -1,10 +1,13 @@
-diff --git a/lib/platform/package.json b/lib/platform/package.json
-index 5ea9d43740d1bdb509612376c0e9ce91d20f8b20..08d4f7327dee5e605107a343d73b2254ed08ddb9 100644
---- a/lib/platform/package.json
-+++ b/lib/platform/package.json
-@@ -1,4 +1,4 @@
- {
--    "main": "./node",
-+    "main": "./node.js",
-     "browser": "./browser"
- }
+diff --git a/package.json b/package.json
+index cbf943bcc31a864f2771e457d327e5106eba9afe..84cb1ce28a4eea4dba60bb4fa6c33a08474b2d3f 100644
+--- a/package.json
++++ b/package.json
+@@ -13,7 +13,7 @@
+     "command"
+   ],
+   "version": "3.2.1",
+-  "main": "lib/advanced/index",
++  "main": "lib/advanced/index.js",
+   "license": "MIT",
+   "sideEffects": false,
+   "repository": {

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,12 +1364,12 @@ __metadata:
 
 "clipanion@patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch":
   version: 3.2.1
-  resolution: "clipanion@patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch::version=3.2.1&hash=cd5507"
+  resolution: "clipanion@patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch::version=3.2.1&hash=687f75"
   dependencies:
     typanion: "npm:^3.8.0"
   peerDependencies:
     typanion: "*"
-  checksum: 10c0/a833a309638d9d07eaa1e4729653944f06998ce9295bc7db5ddbffc136050e41397c4f04c25a5bdc9305ac540f5c7323b7b113a4d1da134c9c552fb3206355f6
+  checksum: 10c0/0acf7ca40c196b76b166ebb0dc7504980567cb12e5d81343d53e3e9a7e13ae24b93f338cd560114984b468b9a2b989ccabdc5247813eeb293b8757df8854d836
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- closes https://github.com/nodejs/corepack/issues/813

## Situation

This repo is configured internally using [yarn@4.11.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.11.0) (released Nov 2025) with the default Yarn Modern configuration setting [nodeLinker: pnp](https://yarnpkg.com/configuration/yarnrc#nodeLinker).

As described in issue https://github.com/nodejs/corepack/issues/813, the CI workflow [ci.yml](https://github.com/nodejs/corepack/actions/workflows/ci.yml) fails in Node.js 24.15.0, leading to an inability to maintain the repo.

The failing jobs are:

- Testing chores
- ubuntu-latest w/ Node.js 24.x
- macos-latest w/ Node.js 24.x

## Assessment

Yarn Modern with `pnp` setting is not compatible with Node.js Active LTS 24.15.0

Edit: Runner image update:

- macos-15 is now updated to Node.js 24.15.0 however and shows a hard error without this PR.
- The next Ubuntu deployment can be expected to update to Node.js 24.15.0 

During deployments, which typically may take several days, GitHub Actions jobs may be served by either the previous image version or the one being deployed. This means that failures are random until the deployment has completed. Deployments can be monitored on [actions/runner-images](https://github.com/actions/runner-images#available-images).

Attempting to resolve the issue by updating Yarn to the latest release [yarn@4.14.1](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.14.1), keeping the default [nodeLinker: pnp](https://yarnpkg.com/configuration/yarnrc#nodeLinker) configuration, replaces the error condition `EBADF` with a `TypeError`. This is not a solution.

A Node.js workaround has ~~also been proposed~~ now been landed through PR https://github.com/nodejs/node/pull/62835. This would need to be available in Node.js 24. There are many unknowns concerning the possible availability, including the delay in the release of Node.js 26.0.0. Possibly, if all goes well, the workaround could be available in mid May 2026 in Node.js 24. Relying on the workaround however would mean that in the interim period, Dependabot update PRs would fail, as would release PRs. The duration is also not predictable. ~~, and assumes that the open PR for the workaround will be approved and that it lands.~~

## Change

To fix the issue without delay, migrate the `nodeLinker` configuration setting from its default value to an explicit<br>`node-modules` setting in a new [.yarnrc.yml](https://yarnpkg.com/configuration/yarnrc) settings file:

| Before            | After                      |
| ----------------- | -------------------------- |
| `nodeLinker: pnp` | `nodeLinker: node-modules` |

To achieve this, cherry-pick https://github.com/nodejs/corepack/pull/652/changes/22a3fc0f823274cbd2d349a8ebed3e205ba2f1c5 from PR https://github.com/nodejs/corepack/pull/652 originally submitted by @geigerzaehler.

The setting has no effect on the npm module published as [corepack](https://www.npmjs.com/package/corepack) to the npm registry, apart from unblocking the ability to publish new versions of the package. The `nodeLinker` setting is not part of the published npm module.

## Verification

On Ubuntu 24.04.4 LTS, with Node.js 24.15.0 LTS, execute:

```shell
corepack yarn install
corepack yarn build
corepack yarn typecheck
corepack yarn lint
corepack yarn test
```

Confirm no errors and all tests passing.