### PR TITLE
doc: remove Node.js 18 mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,6 @@ same major line. Should you need to upgrade to a new major, use an explicit
   Only keys that start with `COREPACK_` and are not in the exception list
   (`COREPACK_ENABLE_DOWNLOAD_PROMPT` and `COREPACK_ENV_FILE` are ignored)
   will be taken into account.
-  For Node.js 18.x users, this setting has no effect as that version doesn't
-  support parsing of `.env` files.
 
 - `COREPACK_HOME` can be set in order to define where Corepack should install
   the package managers. By default it is set to `%LOCALAPPDATA%\node\corepack`


### PR DESCRIPTION
We no longer support Node.js 18