### PR TITLE
fix: target node 22.22.2 in esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "build": "run clean && run build:bundle && tsx ./mkshims.ts",
-    "build:bundle": "esbuild ./sources/_lib.ts --bundle --platform=node --target=node18.17.0 --external:corepack --outfile='./dist/lib/corepack.cjs' --resolve-extensions='.ts,.mjs,.js'",
+    "build:bundle": "esbuild ./sources/_lib.ts --bundle --platform=node --target=node22.22.2 --external:corepack --outfile='./dist/lib/corepack.cjs' --resolve-extensions='.ts,.mjs,.js'",
     "clean": "run rimraf dist shims",
     "corepack": "tsx ./sources/_cli.ts",
     "lint": "eslint .",


### PR DESCRIPTION
## Situation

The npm script `build:bundle` selects `esbuild --target=node18.17.0`

See
- https://esbuild.github.io/getting-started/#bundling-for-node
- https://esbuild.github.io/api/#target

This may unnecessarily transform JavaScript syntax to the earlier EOL Node.js 18 version, although the repo is now set to minimum Node.js 22.22.2

https://github.com/nodejs/corepack/blob/05bc5f3df188f135e0924207f378dfa89afc55bf/package.json#L12-L14

## Change

Update `build:bundle` to `--target=node22.22.2`