### PR TITLE
test: remove esbuild config for vitest

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,7 +7,4 @@ export default defineConfig({
     testTimeout: 120000,
     retry: 2,
   },
-  esbuild: {
-    target: `node${process.versions.node}`,
-  },
 });


### PR DESCRIPTION
## Situation

`corepack yarn test` outputs the warning similar to the following:

> Both esbuild and oxc options were set. oxc options will be used and esbuild options will be ignored. The following esbuild options were set: `{ target: 'node24.14.1' }`


https://github.com/nodejs/corepack/blob/05bc5f3df188f135e0924207f378dfa89afc55bf/vitest.config.mts#L10-L12

## Change

In [vitest.config.mts](https://github.com/nodejs/corepack/blob/main/vitest.config.mts) remove the conflicting `esbuild.target`

This is being ignored and oxc automatically targets the current Node.js version, which is also the intention of the `esbuild` key.
