### PR TITLE
chore: migrate to nodeLinker: node-modules

### DIFF
--- a/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch
+++ b/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch
@@ -1,10 +1,13 @@
-diff --git a/lib/platform/package.json b/lib/platform/package.json
-index 5ea9d43740d1bdb509612376c0e9ce91d20f8b20..08d4f7327dee5e605107a343d73b2254ed08ddb9 100644
---- a/lib/platform/package.json
-+++ b/lib/platform/package.json
-@@ -1,4 +1,4 @@
- {
--    "main": "./node",
-+    "main": "./node.js",
-     "browser": "./browser"
- }
+diff --git a/package.json b/package.json
+index cbf943bcc31a864f2771e457d327e5106eba9afe..84cb1ce28a4eea4dba60bb4fa6c33a08474b2d3f 100644
+--- a/package.json
++++ b/package.json
+@@ -13,7 +13,7 @@
+     "command"
+   ],
+   "version": "3.2.1",
+-  "main": "lib/advanced/index",
++  "main": "lib/advanced/index.js",
+   "license": "MIT",
+   "sideEffects": false,
+   "repository": {

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,12 +1172,12 @@ __metadata:
 
 "clipanion@patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch":
   version: 3.2.1
-  resolution: "clipanion@patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch::version=3.2.1&hash=cd5507"
+  resolution: "clipanion@patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch::version=3.2.1&hash=687f75"
   dependencies:
     typanion: "npm:^3.8.0"
   peerDependencies:
     typanion: "*"
-  checksum: 10c0/a833a309638d9d07eaa1e4729653944f06998ce9295bc7db5ddbffc136050e41397c4f04c25a5bdc9305ac540f5c7323b7b113a4d1da134c9c552fb3206355f6
+  checksum: 10c0/0acf7ca40c196b76b166ebb0dc7504980567cb12e5d81343d53e3e9a7e13ae24b93f338cd560114984b468b9a2b989ccabdc5247813eeb293b8757df8854d836
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- closes https://github.com/nodejs/corepack/issues/837
- supersedes https://github.com/nodejs/corepack/pull/817

## Situation

`corepack yarn lint` fails with Node.js 24.15.0 LTS

> TypeError: Cannot convert undefined or null to object

Node.js 24.15.0 is currently rolling out in `ubuntu-latest`, so failures are sporadic.

The corresponding upstream issue https://github.com/yarnpkg/berry/issues/7106 is unresolved.

## Change

Migrate the `nodeLinker` configuration setting from its default value to an explicit `node-modules` setting in a new [.yarnrc.yml](https://yarnpkg.com/configuration/yarnrc) settings file:

| Before            | After                      |
| ----------------- | -------------------------- |
| `nodeLinker: pnp` | `nodeLinker: node-modules` |

To achieve this, cherry-pick https://github.com/nodejs/corepack/pull/652/changes/22a3fc0f823274cbd2d349a8ebed3e205ba2f1c5 from PR https://github.com/nodejs/corepack/pull/652 originally submitted by @geigerzaehler.

The setting has no effect on the npm module published as [corepack](https://www.npmjs.com/package/corepack) to the npm registry, apart from allowing the CI job `chore` ("Testing chores") to succeed under Node.js >=24.15.0. The `nodeLinker` setting is not part of the published npm module.

## Verification

On Ubuntu 24.04.4 LTS, with Node.js 24.15.0 LTS, execute:

```shell
corepack yarn install
corepack yarn build
corepack yarn typecheck
corepack yarn lint
corepack yarn test
```

Confirm no errors and all tests passing.
