### PR TITLE
chore(*): refactor to use built-in `--strip-types` Node.js flag

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ export default [
         name: `fetch`,
         message: `Use fetch from sources/httpUtils.ts`,
       }],
+      '@typescript-eslint/consistent-type-imports': `error`,
       '@typescript-eslint/no-unused-vars': [`error`, {
         caughtErrors: `none`,
       }],

--- a/genlist.ts
+++ b/genlist.ts
@@ -1,5 +1,5 @@
 import {readFileSync} from 'fs';
-import semverCompare  from 'semver/functions/compare';
+import semverCompare  from 'semver/functions/compare.js';
 
 const lines = readFileSync(0, `utf8`).split(/\n/).filter(line => line);
 

--- a/mkshims.ts
+++ b/mkshims.ts
@@ -2,8 +2,8 @@ import cmdShim                      from '@zkochan/cmd-shim';
 import fs                           from 'fs';
 import path                         from 'path';
 
-import {Engine}                     from './sources/Engine';
-import {SupportedPackageManagerSet} from './sources/types';
+import {Engine}                     from './sources/Engine.ts';
+import {SupportedPackageManagerSet} from './sources/types.ts';
 
 const engine = new Engine();
 

--- a/mkshims.ts
+++ b/mkshims.ts
@@ -7,8 +7,8 @@ import {SupportedPackageManagerSet} from './sources/types.ts';
 
 const engine = new Engine();
 
-const distDir = path.join(__dirname, `dist`);
-const shimsDir = path.join(__dirname, `shims`);
+const distDir = path.join(import.meta.dirname, `dist`);
+const shimsDir = path.join(import.meta.dirname, `shims`);
 
 const physicalNodewinDir = path.join(shimsDir, `nodewin`);
 const virtualNodewinDir = path.join(physicalNodewinDir, `node_modules/corepack`);
@@ -59,7 +59,7 @@ async function main() {
 
   // Last note: cmdShim generates shims with relative paths, so it doesn't matter
   // that the target files don't truly exist, as long as we mock the `stat` function.
-  const remapPath = (p: string) => path.resolve(__dirname, path.relative(virtualNodewinDir, p));
+  const remapPath = (p: string) => path.resolve(import.meta.dirname, path.relative(virtualNodewinDir, p));
 
   const easyStatFs = Object.assign(Object.create(fs), {
     readFile: (p: string, encoding: BufferEncoding, cb: (err: any, str: string) => void) => fs.readFile(remapPath(p), encoding, cb),

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "semver": "^7.6.3",
     "supports-color": "^10.0.0",
     "tar": "^7.5.11",
-    "tsx": "^4.16.2",
     "typescript": "^5.7.3",
     "v8-compile-cache": "^2.3.0",
     "vitest": "^4.0.5",
@@ -45,10 +44,10 @@
     }
   },
   "scripts": {
-    "build": "run clean && run build:bundle && tsx ./mkshims.ts",
+    "build": "run clean && run build:bundle && node ./mkshims.ts",
     "build:bundle": "esbuild ./sources/_lib.ts --bundle --platform=node --target=node22.22.2 --external:corepack --outfile='./dist/lib/corepack.cjs' --resolve-extensions='.ts,.mjs,.js'",
     "clean": "run rimraf dist shims",
-    "corepack": "tsx ./sources/_cli.ts",
+    "corepack": "node ./sources/_cli.ts",
     "lint": "eslint .",
     "prepack": "yarn build",
     "postpack": "run clean",

--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -1,22 +1,24 @@
-import {UsageError}                                           from 'clipanion';
-import fs                                                     from 'fs';
-import path                                                   from 'path';
-import process                                                from 'process';
-import semverRcompare                                         from 'semver/functions/rcompare';
-import semverValid                                            from 'semver/functions/valid';
-import semverValidRange                                       from 'semver/ranges/valid';
+import {UsageError}                                    from 'clipanion';
+import fs                                              from 'fs';
+import path                                            from 'path';
+import process                                         from 'process';
+import semverRcompare                                  from 'semver/functions/rcompare.js';
+import semverValid                                     from 'semver/functions/valid.js';
+import semverValidRange                                from 'semver/ranges/valid.js';
 
-import defaultConfig                                          from '../config.json';
+import defaultConfig                                   from '../config.json' with {type: 'json'};
 
-import * as corepackUtils                                     from './corepackUtils';
-import * as debugUtils                                        from './debugUtils';
-import * as folderUtils                                       from './folderUtils';
-import type {NodeError}                                       from './nodeUtils';
-import * as semverUtils                                       from './semverUtils';
-import * as specUtils                                         from './specUtils';
-import {Config, Descriptor, LazyLocator, Locator}             from './types';
-import {SupportedPackageManagers, SupportedPackageManagerSet} from './types';
-import {isSupportedPackageManager, PackageManagerSpec}        from './types';
+import * as corepackUtils                              from './corepackUtils.ts';
+import * as debugUtils                                 from './debugUtils.ts';
+import * as folderUtils                                from './folderUtils.ts';
+import type {NodeError}                                from './nodeUtils.ts';
+import * as semverUtils                                from './semverUtils.ts';
+import * as specUtils                                  from './specUtils.ts';
+import type {Config, Descriptor, LazyLocator, Locator} from './types.ts';
+import type {SupportedPackageManagers}                 from './types.ts';
+import {SupportedPackageManagerSet}                    from './types.ts';
+import type {PackageManagerSpec}                       from './types.ts';
+import {isSupportedPackageManager}                     from './types.ts';
 
 export type PreparedPackageManagerInfo = Awaited<ReturnType<Engine[`ensurePackageManager`]>>;
 
@@ -94,7 +96,10 @@ export async function activatePackageManager(lastKnownGood: Record<string, strin
 }
 
 export class Engine {
-  constructor(public config: Config = defaultConfig as Config) {
+  config: Config;
+
+  constructor(config: Config = defaultConfig as Config) {
+    this.config = config;
   }
 
   getPackageManagerFor(binaryName: string): SupportedPackageManagers | null {
@@ -161,7 +166,7 @@ export class Engine {
   async getDefaultDescriptors() {
     const locators: Array<Descriptor> = [];
 
-    for (const name of SupportedPackageManagerSet as Set<SupportedPackageManagers>)
+    for (const name of SupportedPackageManagerSet)
       locators.push({name, range: await this.getDefaultVersion(name)});
 
     return locators;

--- a/sources/_cli.ts
+++ b/sources/_cli.ts
@@ -1,3 +1,3 @@
-import {runMain} from './main';
+import {runMain} from './main.ts';
 
 runMain(process.argv.slice(2));

--- a/sources/_lib.ts
+++ b/sources/_lib.ts
@@ -1,1 +1,1 @@
-export {runMain} from './main';
+export {runMain} from './main.ts';

--- a/sources/commands/Base.ts
+++ b/sources/commands/Base.ts
@@ -1,9 +1,9 @@
-import {Command, UsageError}        from 'clipanion';
+import {Command, UsageError}             from 'clipanion';
 
-import {PreparedPackageManagerInfo} from '../Engine';
-import * as corepackUtils           from '../corepackUtils';
-import {Context}                    from '../main';
-import * as specUtils               from '../specUtils';
+import type {PreparedPackageManagerInfo} from '../Engine.ts';
+import * as corepackUtils                from '../corepackUtils.ts';
+import type {Context}                    from '../main.ts';
+import * as specUtils                    from '../specUtils.ts';
 
 export abstract class BaseCommand extends Command<Context> {
   async resolvePatternsToDescriptors({patterns}: {patterns: Array<string>}) {

--- a/sources/commands/Cache.ts
+++ b/sources/commands/Cache.ts
@@ -1,8 +1,8 @@
 import {Command}          from 'clipanion';
 import fs                 from 'fs';
 
-import {getInstallFolder} from '../folderUtils';
-import type {Context}     from '../main';
+import {getInstallFolder} from '../folderUtils.ts';
+import type {Context}     from '../main.ts';
 
 export class CacheCommand extends Command<Context> {
   static paths = [

--- a/sources/commands/Disable.ts
+++ b/sources/commands/Disable.ts
@@ -3,10 +3,10 @@ import fs                                                                from 'f
 import path                                                              from 'path';
 import which                                                             from 'which';
 
-import * as corepackUtils                                                from '../corepackUtils';
-import {Context}                                                         from '../main';
-import type {NodeError}                                                  from '../nodeUtils';
-import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types';
+import * as corepackUtils                                                from '../corepackUtils.ts';
+import type {Context}                                                    from '../main.ts';
+import type {NodeError}                                                  from '../nodeUtils.ts';
+import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types.ts';
 
 export class DisableCommand extends Command<Context> {
   static paths = [

--- a/sources/commands/Enable.ts
+++ b/sources/commands/Enable.ts
@@ -4,9 +4,9 @@ import fs                                                                from 'f
 import path                                                              from 'path';
 import which                                                             from 'which';
 
-import * as corepackUtils                                                from '../corepackUtils';
-import {Context}                                                         from '../main';
-import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types';
+import * as corepackUtils                                                from '../corepackUtils.ts';
+import type {Context}                                                    from '../main.ts';
+import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types.ts';
 
 export class EnableCommand extends Command<Context> {
   static paths = [

--- a/sources/commands/InstallGlobal.ts
+++ b/sources/commands/InstallGlobal.ts
@@ -1,12 +1,13 @@
-import {Command, Option, UsageError}                    from 'clipanion';
-import fs                                               from 'fs';
-import path                                             from 'path';
+import {Command, Option, UsageError} from 'clipanion';
+import fs                            from 'fs';
+import path                          from 'path';
 
-import * as folderUtils                                 from '../folderUtils';
-import * as specUtils                                   from '../specUtils';
-import {Descriptor, Locator, isSupportedPackageManager} from '../types';
+import * as folderUtils              from '../folderUtils.ts';
+import * as specUtils                from '../specUtils.ts';
+import type {Descriptor, Locator}    from '../types.ts';
+import {isSupportedPackageManager}   from '../types.ts';
 
-import {BaseCommand}                                    from './Base';
+import {BaseCommand}                 from './Base.ts';
 
 export class InstallGlobalCommand extends BaseCommand {
   static paths = [

--- a/sources/commands/InstallLocal.ts
+++ b/sources/commands/InstallLocal.ts
@@ -1,6 +1,6 @@
 import {Command, UsageError} from 'clipanion';
 
-import {BaseCommand}         from './Base';
+import {BaseCommand}         from './Base.ts';
 
 export class InstallLocalCommand extends BaseCommand {
   static paths = [

--- a/sources/commands/Pack.ts
+++ b/sources/commands/Pack.ts
@@ -2,9 +2,9 @@ import {Command, Option, UsageError} from 'clipanion';
 import {mkdir}                       from 'fs/promises';
 import path                          from 'path';
 
-import * as folderUtils              from '../folderUtils';
+import * as folderUtils              from '../folderUtils.ts';
 
-import {BaseCommand}                 from './Base';
+import {BaseCommand}                 from './Base.ts';
 
 export class PackCommand extends BaseCommand {
   static paths = [

--- a/sources/commands/Up.ts
+++ b/sources/commands/Up.ts
@@ -1,11 +1,11 @@
 import {Command, UsageError}           from 'clipanion';
-import semverMajor                     from 'semver/functions/major';
-import semverValid                     from 'semver/functions/valid';
-import semverValidRange                from 'semver/ranges/valid';
+import semverMajor                     from 'semver/functions/major.js';
+import semverValid                     from 'semver/functions/valid.js';
+import semverValidRange                from 'semver/ranges/valid.js';
 
-import type {SupportedPackageManagers} from '../types';
+import type {SupportedPackageManagers} from '../types.ts';
 
-import {BaseCommand}                   from './Base';
+import {BaseCommand}                   from './Base.ts';
 
 export class UpCommand extends BaseCommand {
   static paths = [

--- a/sources/commands/Use.ts
+++ b/sources/commands/Use.ts
@@ -1,6 +1,6 @@
 import {Command, Option, UsageError} from 'clipanion';
 
-import {BaseCommand}                 from './Base';
+import {BaseCommand}                 from './Base.ts';
 
 export class UseCommand extends BaseCommand {
   static paths = [

--- a/sources/commands/deprecated/Hydrate.ts
+++ b/sources/commands/deprecated/Hydrate.ts
@@ -2,9 +2,9 @@ import {Command, Option, UsageError} from 'clipanion';
 import {mkdir}                       from 'fs/promises';
 import path                          from 'path';
 
-import * as folderUtils              from '../../folderUtils';
-import {Context}                     from '../../main';
-import {isSupportedPackageManager}   from '../../types';
+import * as folderUtils              from '../../folderUtils.ts';
+import type {Context}                from '../../main.ts';
+import {isSupportedPackageManager}   from '../../types.ts';
 
 export class HydrateCommand extends Command<Context> {
   static paths = [

--- a/sources/commands/deprecated/Prepare.ts
+++ b/sources/commands/deprecated/Prepare.ts
@@ -2,10 +2,10 @@ import {Command, Option, UsageError} from 'clipanion';
 import {mkdir}                       from 'fs/promises';
 import path                          from 'path';
 
-import * as folderUtils              from '../../folderUtils';
-import {Context}                     from '../../main';
-import * as specUtils                from '../../specUtils';
-import {Descriptor}                  from '../../types';
+import * as folderUtils              from '../../folderUtils.ts';
+import type {Context}                from '../../main.ts';
+import * as specUtils                from '../../specUtils.ts';
+import type {Descriptor}             from '../../types.ts';
 
 export class PrepareCommand extends Command<Context> {
   static paths = [

--- a/sources/corepackUtils.ts
+++ b/sources/corepackUtils.ts
@@ -1,23 +1,23 @@
-import {createHash}                                            from 'crypto';
-import {once}                                                  from 'events';
-import fs                                                      from 'fs';
-import type {Dir}                                              from 'fs';
-import Module                                                  from 'module';
-import path                                                    from 'path';
-import Range                                                   from 'semver/classes/range';
-import SemVer                                                  from 'semver/classes/semver';
-import semverLt                                                from 'semver/functions/lt';
-import semverParse                                             from 'semver/functions/parse';
-import {setTimeout as setTimeoutPromise}                       from 'timers/promises';
+import {createHash}                                                 from 'crypto';
+import {once}                                                       from 'events';
+import fs                                                           from 'fs';
+import type {Dir}                                                   from 'fs';
+import Module                                                       from 'module';
+import path                                                         from 'path';
+import Range                                                        from 'semver/classes/range.js';
+import SemVer                                                       from 'semver/classes/semver.js';
+import semverLt                                                     from 'semver/functions/lt.js';
+import semverParse                                                  from 'semver/functions/parse.js';
+import {setTimeout as setTimeoutPromise}                            from 'timers/promises';
 
-import * as engine                                             from './Engine';
-import * as debugUtils                                         from './debugUtils';
-import * as folderUtils                                        from './folderUtils';
-import * as httpUtils                                          from './httpUtils';
-import * as nodeUtils                                          from './nodeUtils';
-import * as npmRegistryUtils                                   from './npmRegistryUtils';
-import {RegistrySpec, Descriptor, Locator, PackageManagerSpec} from './types';
-import {BinList, BinSpec, InstallSpec, DownloadSpec}           from './types';
+import * as engine                                                  from './Engine.ts';
+import * as debugUtils                                              from './debugUtils.ts';
+import * as folderUtils                                             from './folderUtils.ts';
+import * as httpUtils                                               from './httpUtils.ts';
+import * as nodeUtils                                               from './nodeUtils.ts';
+import * as npmRegistryUtils                                        from './npmRegistryUtils.ts';
+import type {RegistrySpec, Descriptor, Locator, PackageManagerSpec} from './types.ts';
+import type {BinList, BinSpec, InstallSpec, DownloadSpec}           from './types.ts';
 
 const YARN_SWITCH_REGEX = /[/\\]switch[/\\]bin[/\\]/;
 

--- a/sources/folderUtils.ts
+++ b/sources/folderUtils.ts
@@ -4,7 +4,7 @@ import {homedir, tmpdir} from 'os';
 import {join}            from 'path';
 import process           from 'process';
 
-import type {NodeError}  from './nodeUtils';
+import type {NodeError}  from './nodeUtils.ts';
 
 /**
  * If the install folder structure changes then increment this number.

--- a/sources/httpUtils.ts
+++ b/sources/httpUtils.ts
@@ -4,7 +4,7 @@ import {once}                     from 'events';
 import {stderr, stdin}            from 'process';
 import {Readable}                 from 'stream';
 
-import {DEFAULT_NPM_REGISTRY_URL} from './npmRegistryUtils';
+import {DEFAULT_NPM_REGISTRY_URL} from './npmRegistryUtils.ts';
 
 async function fetch(input: string | URL, init?: RequestInit) {
   if (process.env.COREPACK_ENABLE_NETWORK === `0`)

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -1,22 +1,25 @@
-import {BaseContext, Builtins, Cli}    from 'clipanion';
-import type {UsageError}               from 'clipanion';
+import {Builtins, Cli}                from 'clipanion';
+import type {UsageError, BaseContext} from 'clipanion';
 
-import {version as corepackVersion}    from '../package.json';
+import pJSON                          from '../package.json' with {type: 'json'};
 
-import {Engine, PackageManagerRequest} from './Engine';
-import {CacheCommand}                  from './commands/Cache';
-import {DisableCommand}                from './commands/Disable';
-import {EnableCommand}                 from './commands/Enable';
-import {InstallGlobalCommand}          from './commands/InstallGlobal';
-import {InstallLocalCommand}           from './commands/InstallLocal';
-import {PackCommand}                   from './commands/Pack';
-import {UpCommand}                     from './commands/Up';
-import {UseCommand}                    from './commands/Use';
-import {HydrateCommand}                from './commands/deprecated/Hydrate';
-import {PrepareCommand}                from './commands/deprecated/Prepare';
+import type {PackageManagerRequest}   from './Engine.ts';
+import {Engine}                       from './Engine.ts';
+import {CacheCommand}                 from './commands/Cache.ts';
+import {DisableCommand}               from './commands/Disable.ts';
+import {EnableCommand}                from './commands/Enable.ts';
+import {InstallGlobalCommand}         from './commands/InstallGlobal.ts';
+import {InstallLocalCommand}          from './commands/InstallLocal.ts';
+import {PackCommand}                  from './commands/Pack.ts';
+import {UpCommand}                    from './commands/Up.ts';
+import {UseCommand}                   from './commands/Use.ts';
+import {HydrateCommand}               from './commands/deprecated/Hydrate.ts';
+import {PrepareCommand}               from './commands/deprecated/Prepare.ts';
 
 export type CustomContext = {cwd: string, engine: Engine};
 export type Context = BaseContext & CustomContext;
+
+const {version: corepackVersion} = pJSON;
 
 function getPackageManagerRequestFromCli(parameter: string | undefined, engine: Engine): PackageManagerRequest | null {
   if (!parameter)

--- a/sources/npmRegistryUtils.ts
+++ b/sources/npmRegistryUtils.ts
@@ -1,10 +1,10 @@
 import {UsageError}               from 'clipanion';
 import {createVerify}             from 'crypto';
 
-import defaultConfig              from '../config.json';
+import defaultConfig              from '../config.json' with {type: 'json'};
 
-import {shouldSkipIntegrityCheck} from './corepackUtils';
-import * as httpUtils             from './httpUtils';
+import {shouldSkipIntegrityCheck} from './corepackUtils.ts';
+import * as httpUtils             from './httpUtils.ts';
 
 // load abbreviated metadata as that's all we need for these calls
 // see: https://github.com/npm/registry/blob/cfe04736f34db9274a780184d1cdb2fb3e4ead2a/docs/responses/package-metadata.md

--- a/sources/semverUtils.ts
+++ b/sources/semverUtils.ts
@@ -1,5 +1,5 @@
-import Range  from 'semver/classes/range';
-import SemVer from 'semver/classes/semver';
+import Range  from 'semver/classes/range.js';
+import SemVer from 'semver/classes/semver.js';
 
 /**
  * Returns whether the given semver version satisfies the given range. Notably

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -1,17 +1,17 @@
-import {UsageError}                            from 'clipanion';
-import fs                                      from 'fs';
-import path                                    from 'path';
-import semverSatisfies                         from 'semver/functions/satisfies';
-import semverValid                             from 'semver/functions/valid';
-import semverValidRange                        from 'semver/ranges/valid';
-import {parseEnv}                              from 'util';
+import {UsageError}                      from 'clipanion';
+import fs                                from 'fs';
+import path                              from 'path';
+import semverSatisfies                   from 'semver/functions/satisfies.js';
+import semverValid                       from 'semver/functions/valid.js';
+import semverValidRange                  from 'semver/ranges/valid.js';
+import {parseEnv}                        from 'util';
 
-import {PreparedPackageManagerInfo}            from './Engine';
-import * as debugUtils                         from './debugUtils';
-import {NodeError}                             from './nodeUtils';
-import * as nodeUtils                          from './nodeUtils';
-import {Descriptor, isSupportedPackageManager} from './types';
-import type {LocalEnvFile}                     from './types';
+import type {PreparedPackageManagerInfo} from './Engine.ts';
+import * as debugUtils                   from './debugUtils.ts';
+import type {NodeError}                  from './nodeUtils.ts';
+import * as nodeUtils                    from './nodeUtils.ts';
+import {isSupportedPackageManager}       from './types.ts';
+import type {LocalEnvFile, Descriptor}   from './types.ts';
 
 const nodeModulesRegExp = /[\\/]node_modules[\\/](@[^\\/]*[\\/])?([^@\\/][^\\/]*)$/;
 

--- a/sources/types.ts
+++ b/sources/types.ts
@@ -1,22 +1,17 @@
 export type BinSpec = {[key: string]: string};
 export type BinList = Array<string>;
 
-export enum SupportedPackageManagers {
-  Npm = `npm`,
-  Pnpm = `pnpm`,
-  Yarn = `yarn`,
-}
+export type SupportedPackageManagers = `npm` | `pnpm` | `yarn`;
 
-export const SupportedPackageManagerSet = new Set<SupportedPackageManagers>(
-  Object.values(SupportedPackageManagers),
+const supportedPackageManagersList: Array<SupportedPackageManagers> = [`npm`, `pnpm`, `yarn`];
+
+export const SupportedPackageManagerSet: ReadonlySet<SupportedPackageManagers> = new Set<SupportedPackageManagers>(
+  supportedPackageManagersList,
 );
 
-export const SupportedPackageManagerSetWithoutNpm = new Set<SupportedPackageManagers>(
-  Object.values(SupportedPackageManagers),
+export const SupportedPackageManagerSetWithoutNpm: ReadonlySet<SupportedPackageManagers> = new Set<SupportedPackageManagers>(
+  supportedPackageManagersList.filter(pm => pm !== `npm`),
 );
-
-// npm is distributed with Node as a builtin; we don't want Corepack to override it unless the npm team is on board
-SupportedPackageManagerSetWithoutNpm.delete(SupportedPackageManagers.Npm);
 
 export function isSupportedPackageManager(value: string): value is SupportedPackageManagers {
   return SupportedPackageManagerSet.has(value as SupportedPackageManagers);

--- a/tests/Disable.test.ts
+++ b/tests/Disable.test.ts
@@ -1,13 +1,14 @@
-import {Filename, ppath, xfs, npath}          from '@yarnpkg/fslib';
+import type {Filename}                        from '@yarnpkg/fslib';
+import {ppath, xfs, npath}                    from '@yarnpkg/fslib';
 import {delimiter}                            from 'node:path';
 import process                                from 'node:process';
 import {describe, beforeEach, it, expect}     from 'vitest';
 
-import {Engine}                               from '../sources/Engine';
-import {SupportedPackageManagerSetWithoutNpm} from '../sources/types';
+import {Engine}                               from '../sources/Engine.ts';
+import {SupportedPackageManagerSetWithoutNpm} from '../sources/types.ts';
 
-import {makeBin, getBinaryNames}              from './_binHelpers';
-import {runCli}                               from './_runCli';
+import {makeBin, getBinaryNames}              from './_binHelpers.ts';
+import {runCli}                               from './_runCli.ts';
 
 const engine = new Engine();
 

--- a/tests/Enable.test.ts
+++ b/tests/Enable.test.ts
@@ -1,14 +1,15 @@
-import {Filename, ppath, xfs, npath}                                    from '@yarnpkg/fslib';
-import {delimiter}                                                      from 'node:path';
-import process                                                          from 'node:process';
-import {setTimeout}                                                     from 'node:timers/promises';
-import {describe, beforeEach, it, expect, test}                         from 'vitest';
+import type {Filename}                          from '@yarnpkg/fslib';
+import {ppath, xfs, npath}                      from '@yarnpkg/fslib';
+import {delimiter}                              from 'node:path';
+import process                                  from 'node:process';
+import {setTimeout}                             from 'node:timers/promises';
+import {describe, beforeEach, it, expect, test} from 'vitest';
 
-import {Engine}                                                         from '../sources/Engine';
-import {SupportedPackageManagers, SupportedPackageManagerSetWithoutNpm} from '../sources/types';
+import {Engine}                                 from '../sources/Engine.ts';
+import {SupportedPackageManagerSetWithoutNpm}   from '../sources/types.ts';
 
-import {makeBin, getBinaryNames}                                        from './_binHelpers';
-import {runCli}                                                         from './_runCli';
+import {makeBin, getBinaryNames}                from './_binHelpers.ts';
+import {runCli}                                 from './_runCli.ts';
 
 const engine = new Engine();
 
@@ -81,7 +82,7 @@ describe(`EnableCommand`, () => {
       });
 
       const expectedEntries: Array<string> = [ppath.basename(corepackBin)];
-      for (const binName of engine.getBinariesFor(SupportedPackageManagers.Yarn))
+      for (const binName of engine.getBinariesFor(`yarn`))
         expectedEntries.push(...getBinaryNames(binName));
 
       await expect(sortedEntries).resolves.toEqual(expectedEntries.sort());

--- a/tests/Up.test.ts
+++ b/tests/Up.test.ts
@@ -2,7 +2,7 @@ import {ppath, xfs, npath}                from '@yarnpkg/fslib';
 import process                            from 'node:process';
 import {describe, beforeEach, it, expect} from 'vitest';
 
-import {runCli}                           from './_runCli';
+import {runCli}                           from './_runCli.ts';
 
 beforeEach(async () => {
   const home = await xfs.mktempPromise();

--- a/tests/Use.test.ts
+++ b/tests/Use.test.ts
@@ -2,7 +2,7 @@ import {ppath, xfs, npath}                from '@yarnpkg/fslib';
 import process                            from 'node:process';
 import {describe, beforeEach, it, expect} from 'vitest';
 
-import {runCli}                           from './_runCli';
+import {runCli}                           from './_runCli.ts';
 
 beforeEach(async () => {
   const home = await xfs.mktempPromise();

--- a/tests/_binHelpers.ts
+++ b/tests/_binHelpers.ts
@@ -1,4 +1,5 @@
-import {Filename, ppath, xfs, PortablePath} from '@yarnpkg/fslib';
+import type {Filename, PortablePath} from '@yarnpkg/fslib';
+import {ppath, xfs}                  from '@yarnpkg/fslib';
 
 export async function makeBin(cwd: PortablePath, name: Filename, {ignorePlatform = false}: {ignorePlatform?: boolean} = {}) {
   let path = ppath.join(cwd, name);

--- a/tests/_runCli.ts
+++ b/tests/_runCli.ts
@@ -1,7 +1,8 @@
-import {PortablePath, npath} from '@yarnpkg/fslib';
-import {spawn}               from 'child_process';
-import * as path             from 'path';
-import {pathToFileURL}       from 'url';
+import type {PortablePath} from '@yarnpkg/fslib';
+import {npath}             from '@yarnpkg/fslib';
+import {spawn}             from 'child_process';
+import * as path           from 'path';
+import {pathToFileURL}     from 'url';
 
 export async function runCli(cwd: PortablePath, argv: Array<string>, withCustomRegistry?: boolean): Promise<{exitCode: number | null, stdout: string, stderr: string}> {
   const out: Array<Buffer> = [];

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,9 +1,9 @@
 import {vi, describe, it, expect} from 'vitest';
 
-import defaultConfig              from '../config.json';
-import {DEFAULT_NPM_REGISTRY_URL} from '../sources/npmRegistryUtils';
+import defaultConfig              from '../config.json' with {type: 'json'};
+import {DEFAULT_NPM_REGISTRY_URL} from '../sources/npmRegistryUtils.ts';
 
-vi.mock(`../sources/httpUtils`);
+vi.mock(`../sources/httpUtils.ts`);
 
 describe(`key store should be up-to-date`, () => {
   it(`should contain up-to-date npm keys`, async () => {

--- a/tests/corepackUtils.test.ts
+++ b/tests/corepackUtils.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect}     from 'vitest';
 
-import {shouldSkipIntegrityCheck} from '../sources/corepackUtils';
+import {shouldSkipIntegrityCheck} from '../sources/corepackUtils.ts';
 
 describe(`corepack utils shouldSkipIntegrityCheck`, () => {
   it(`should return false if COREPACK_INTEGRITY_KEYS env is not set`, () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,13 +1,14 @@
-import {Filename, ppath, xfs, npath, PortablePath}   from '@yarnpkg/fslib';
+import type {Filename, PortablePath}                 from '@yarnpkg/fslib';
+import {ppath, xfs, npath}                           from '@yarnpkg/fslib';
 import os                                            from 'node:os';
 import process                                       from 'node:process';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
-import config                                        from '../config.json';
-import * as folderUtils                              from '../sources/folderUtils';
-import {SupportedPackageManagerSet}                  from '../sources/types';
+import config                                        from '../config.json' with {type: 'json'};
+import * as folderUtils                              from '../sources/folderUtils.ts';
+import {SupportedPackageManagerSet}                  from '../sources/types.ts';
 
-import {runCli}                                      from './_runCli';
+import {runCli}                                      from './_runCli.ts';
 
 
 beforeEach(async () => {

--- a/tests/npmRegistryUtils.test.ts
+++ b/tests/npmRegistryUtils.test.ts
@@ -2,10 +2,10 @@ import {Buffer}                                                 from 'node:buffe
 import process                                                  from 'node:process';
 import {describe, beforeEach, it, expect, vi}                   from 'vitest';
 
-import {fetchAsJson as httpFetchAsJson}                         from '../sources/httpUtils';
-import {DEFAULT_HEADERS, DEFAULT_NPM_REGISTRY_URL, fetchAsJson} from '../sources/npmRegistryUtils';
+import {fetchAsJson as httpFetchAsJson}                         from '../sources/httpUtils.ts';
+import {DEFAULT_HEADERS, DEFAULT_NPM_REGISTRY_URL, fetchAsJson} from '../sources/npmRegistryUtils.ts';
 
-vi.mock(`../sources/httpUtils`);
+vi.mock(`../sources/httpUtils.ts`);
 
 describe(`npm registry utils fetchAsJson`, () => {
   beforeEach(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "esModuleInterop": true,
-    "experimentalDecorators": true,
+    "erasableSyntaxOnly": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["ES2023"],
     "module": "preserve",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,7 +1237,6 @@ __metadata:
     semver: "npm:^7.6.3"
     supports-color: "npm:^10.0.0"
     tar: "npm:^7.5.11"
-    tsx: "npm:^4.16.2"
     typescript: "npm:^5.7.3"
     v8-compile-cache: "npm:^2.3.0"
     vitest: "npm:^4.0.5"
@@ -1515,7 +1514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.28.0, esbuild@npm:~0.28.0":
+"esbuild@npm:^0.28.0":
   version: 0.28.0
   resolution: "esbuild@npm:0.28.0"
   dependencies:
@@ -3416,21 +3415,6 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
-  languageName: node
-  linkType: hard
-
-"tsx@npm:^4.16.2":
-  version: 4.22.0
-  resolution: "tsx@npm:4.22.0"
-  dependencies:
-    esbuild: "npm:~0.28.0"
-    fsevents: "npm:~2.3.3"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    tsx: dist/cli.mjs
-  checksum: 10c0/cc7474ac13eebf6bb4d87ce21bdd79213261a37a6e247a74d7920b3e0ce7b704b42e7642e7978e2f3de5762981b3b74ed0ae14cf60934107aa0b1390f25e46ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With support for Node.js 20 being dropped, we no longer need `tsx` and can rely on the built-in Node.js type stripping