### PR TITLE
fix: clear last known good cache entry

### DIFF
--- a/sources/commands/Cache.ts
+++ b/sources/commands/Cache.ts
@@ -1,8 +1,9 @@
-import {Command}          from 'clipanion';
-import fs                 from 'fs';
+import {Command}                                 from 'clipanion';
+import fs                                        from 'fs';
+import path                                      from 'path';
 
-import {getInstallFolder} from '../folderUtils.ts';
-import type {Context}     from '../main.ts';
+import {getCorepackHomeFolder, getInstallFolder} from '../folderUtils.ts';
+import type {Context}                            from '../main.ts';
 
 export class CacheCommand extends Command<Context> {
   static paths = [
@@ -18,6 +19,9 @@ export class CacheCommand extends Command<Context> {
   });
 
   async execute() {
-    await fs.promises.rm(getInstallFolder(), {recursive: true, force: true});
+    await Promise.all([
+      fs.promises.rm(getInstallFolder(), {recursive: true, force: true}),
+      fs.promises.rm(path.join(getCorepackHomeFolder(), `lastKnownGood.json`), {force: true}),
+    ]);
   }
 }

--- a/tests/Cache.test.ts
+++ b/tests/Cache.test.ts
@@ -1,0 +1,35 @@
+import type {Filename}          from '@yarnpkg/fslib';
+import {npath, ppath, xfs}      from '@yarnpkg/fslib';
+import process                  from 'node:process';
+import {beforeEach, expect, it} from 'vitest';
+
+import {runCli}                 from './_runCli.ts';
+
+
+beforeEach(async () => {
+  const home = await xfs.mktempPromise();
+  process.env.COREPACK_HOME = npath.fromPortablePath(home);
+
+  return async () => {
+    await xfs.removePromise(home, {recursive: true});
+  };
+});
+
+for (const command of [`clean`, `clear`]) {
+  it(`should remove the entire cache with cache ${command}`, async () => {
+    const home = npath.toPortablePath(process.env.COREPACK_HOME!);
+    await xfs.mkdirPromise(ppath.join(home, `v1`), {recursive: true});
+    await xfs.writeFilePromise(ppath.join(home, `v1/package-manager` as Filename), ``);
+    await xfs.writeJsonPromise(ppath.join(home, `lastKnownGood.json` as Filename), {
+      yarn: `4.0.0`,
+    });
+
+    await expect(runCli(home, [`cache`, command])).resolves.toMatchObject({
+      exitCode: 0,
+      stderr: ``,
+      stdout: ``,
+    });
+
+    await expect(xfs.readdirPromise(home)).resolves.toEqual([]);
+  });
+}


### PR DESCRIPTION
## Summary

- remove `lastKnownGood.json` when running either `corepack cache clean` or `corepack cache clear`
- keep deletion scoped to Corepack-managed cache entries instead of recursively removing the configurable cache root
- cover both command aliases with regression tests

Fixes #675

## Tests

- `yarn build`
- `yarn test --run` (173 passed, 1 expected failure)
- `yarn lint`
- `yarn typecheck`